### PR TITLE
Make the contents of byte-wrapping structs public

### DIFF
--- a/src/sodiumoxide/crypto/auth_macros.rs
+++ b/src/sodiumoxide/crypto/auth_macros.rs
@@ -26,7 +26,7 @@ pub static TAGBYTES: uint = $tagbytes;
  * When a `Key` goes out of scope its contents
  * will be zeroed out
  */
-pub struct Key([u8, ..KEYBYTES]);
+pub struct Key(pub [u8, ..KEYBYTES]);
 
 impl Drop for Key {
     fn drop(&mut self) {
@@ -41,7 +41,7 @@ impl Drop for Key {
   * The tag implements the traits `TotalEq` and `Eq` using constant-time
   * comparison functions. See `sodiumoxide::crypto::verify::verify_32`
   */
-pub struct Tag([u8, ..TAGBYTES]);
+pub struct Tag(pub [u8, ..TAGBYTES]);
 impl TotalEq for Tag { }
 impl Eq for Tag {
     fn eq(&self, &Tag(other): &Tag) -> bool {

--- a/src/sodiumoxide/crypto/curve25519.rs
+++ b/src/sodiumoxide/crypto/curve25519.rs
@@ -23,11 +23,11 @@ pub static SCALARBYTES: uint = 32;
 /**
  * `Scalar` value (integer in byte representation)
  */
-pub struct Scalar([u8, ..SCALARBYTES]);
+pub struct Scalar(pub [u8, ..SCALARBYTES]);
 /**
  * `GroupElement`
  */
-pub struct GroupElement([u8, ..BYTES]);
+pub struct GroupElement(pub [u8, ..BYTES]);
 
 /**
  * `scalarmult()` multiplies a group element `p`

--- a/src/sodiumoxide/crypto/curve25519xsalsa20poly1305.rs
+++ b/src/sodiumoxide/crypto/curve25519xsalsa20poly1305.rs
@@ -52,14 +52,14 @@ static BOXZEROBYTES: uint = 16;
 /**
  * `PublicKey` for asymmetric authenticated encryption
  */
-pub struct PublicKey([u8, ..PUBLICKEYBYTES]);
+pub struct PublicKey(pub [u8, ..PUBLICKEYBYTES]);
 /**
  * `SecretKey` for asymmetric authenticated encryption
  *
  * When a `SecretKey` goes out of scope its contents
  * will be zeroed out
  */
-pub struct SecretKey([u8, ..SECRETKEYBYTES]);
+pub struct SecretKey(pub [u8, ..SECRETKEYBYTES]);
 impl Drop for SecretKey {
     fn drop(&mut self) {
         let &SecretKey(ref mut sk) = self;
@@ -70,7 +70,7 @@ impl Drop for SecretKey {
 /**
  * `Nonce` for asymmetric authenticated encryption
  */
-pub struct Nonce([u8, ..NONCEBYTES]);
+pub struct Nonce(pub [u8, ..NONCEBYTES]);
 
 /**
  * `gen_keypair()` randomly generates a secret key and a corresponding public key.

--- a/src/sodiumoxide/crypto/ed25519.rs
+++ b/src/sodiumoxide/crypto/ed25519.rs
@@ -42,7 +42,7 @@ pub static SIGNATUREBYTES: uint = 64;
  * When a `Seed` goes out of scope its contents
  * will be zeroed out
  */
-pub struct Seed([u8, ..SEEDBYTES]);
+pub struct Seed(pub [u8, ..SEEDBYTES]);
 impl Drop for Seed {
     fn drop(&mut self) {
         let &Seed(ref mut s) = self;
@@ -56,7 +56,7 @@ impl Drop for Seed {
  * When a `SecretKey` goes out of scope its contents
  * will be zeroed out
  */
-pub struct SecretKey([u8, ..SECRETKEYBYTES]);
+pub struct SecretKey(pub [u8, ..SECRETKEYBYTES]);
 impl Drop for SecretKey {
     fn drop(&mut self) {
         let &SecretKey(ref mut sk) = self;
@@ -66,7 +66,7 @@ impl Drop for SecretKey {
 /**
  * `PublicKey` for signatures
  */
-pub struct PublicKey([u8, ..PUBLICKEYBYTES]);
+pub struct PublicKey(pub [u8, ..PUBLICKEYBYTES]);
 
 /**
  * `gen_keypair()` randomly generates a secret key and a corresponding public

--- a/src/sodiumoxide/crypto/edwards25519sha512batch.rs
+++ b/src/sodiumoxide/crypto/edwards25519sha512batch.rs
@@ -31,7 +31,7 @@ pub static SIGNATUREBYTES: uint = 64;
  * When a `SecretKey` goes out of scope its contents
  * will be zeroed out
  */
-pub struct SecretKey([u8, ..SECRETKEYBYTES]);
+pub struct SecretKey(pub [u8, ..SECRETKEYBYTES]);
 impl Drop for SecretKey {
     fn drop(&mut self) {
         let &SecretKey(ref mut buf) = self;
@@ -41,7 +41,7 @@ impl Drop for SecretKey {
 /**
  * `PublicKey` for signatures
  */
-pub struct PublicKey([u8, ..PUBLICKEYBYTES]);
+pub struct PublicKey(pub [u8, ..PUBLICKEYBYTES]);
 
 /**
  * `gen_keypair()` randomly generates a secret key and a corresponding public

--- a/src/sodiumoxide/crypto/hash_macros.rs
+++ b/src/sodiumoxide/crypto/hash_macros.rs
@@ -14,7 +14,7 @@ pub static BLOCKBYTES: uint = $blockbytes;
 /**
  * Digest-structure
  */
-pub struct Digest([u8, ..HASHBYTES]);
+pub struct Digest(pub [u8, ..HASHBYTES]);
 
 /**
  * `hash` hashes a message `m`. It returns a hash `h`.

--- a/src/sodiumoxide/crypto/siphash24.rs
+++ b/src/sodiumoxide/crypto/siphash24.rs
@@ -19,7 +19,7 @@ pub static KEYBYTES: uint = 16;
 /**
  * Digest-structure
  */
-pub struct Digest([u8, ..HASHBYTES]);
+pub struct Digest(pub [u8, ..HASHBYTES]);
 
 /**
  * Key
@@ -27,7 +27,7 @@ pub struct Digest([u8, ..HASHBYTES]);
  * When a `Key` goes out of scope its contents
  * will be zeroed out
  */
-pub struct Key([u8, ..KEYBYTES]);
+pub struct Key(pub [u8, ..KEYBYTES]);
 
 impl Drop for Key {
     fn drop(&mut self) {

--- a/src/sodiumoxide/crypto/stream_macros.rs
+++ b/src/sodiumoxide/crypto/stream_macros.rs
@@ -26,7 +26,7 @@ pub static NONCEBYTES: uint = $noncebytes;
  * When a `Key` goes out of scope its contents
  * will be zeroed out
  */
-pub struct Key([u8, ..KEYBYTES]);
+pub struct Key(pub [u8, ..KEYBYTES]);
 impl Drop for Key {
     fn drop(&mut self) {
         let &Key(ref mut k) = self;
@@ -37,7 +37,7 @@ impl Drop for Key {
 /**
  * `Nonce` for symmetric encryption
  */
-pub struct Nonce([u8, ..NONCEBYTES]);
+pub struct Nonce(pub [u8, ..NONCEBYTES]);
 
 /**
  * `gen_key()` randomly generates a key for symmetric encryption

--- a/src/sodiumoxide/crypto/xsalsa20poly1305.rs
+++ b/src/sodiumoxide/crypto/xsalsa20poly1305.rs
@@ -33,7 +33,7 @@ pub static NONCEBYTES: uint = 24;
  * When a `Key` goes out of scope its contents
  * will be zeroed out
  */
-pub struct Key([u8, ..KEYBYTES]);
+pub struct Key(pub [u8, ..KEYBYTES]);
 impl Drop for Key {
     fn drop(&mut self) {
         let &Key(ref mut k) = self;
@@ -44,7 +44,7 @@ impl Drop for Key {
 /**
  * `Nonce` for symmetric authenticated encryption
  */
-pub struct Nonce([u8, ..NONCEBYTES]);
+pub struct Nonce(pub [u8, ..NONCEBYTES]);
 
 pub static ZEROBYTES: uint = 32;
 pub static BOXZEROBYTES: uint = 16;


### PR DESCRIPTION
This allows users of the library to create keys, read digests, etc.
