### PR TITLE
Make AEAD Nonce type a nonce new_type

### DIFF
--- a/src/crypto/aead/aead_macros.rs
+++ b/src/crypto/aead/aead_macros.rs
@@ -29,7 +29,7 @@ new_type! {
 
 new_type! {
     /// `Nonce` for symmetric authenticated encryption with additional data.
-    public Nonce(NONCEBYTES);
+    nonce Nonce(NONCEBYTES);
 }
 
 new_type! {


### PR DESCRIPTION
the Nonce type of AEAD is declared using the `public` new_type bytearray macro, instead of the `nonce` one.

As far as I can tell, the only difference is that it adds the `increment_le` and `increment_le_inplace` methods. Libsodium's documentation says it is safe to use a counter for the AEAD nonce. It so seems to me there is no drawback to making this a nonce type.

Cheers,
--Max