### PR TITLE
Add exclude field to manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,11 @@ readme = "README.md"
 repository = "https://github.com/sodiumoxide/sodiumoxide"
 categories = ["cryptography"]
 version = "0.0.16"
+exclude = [
+    "**/.gitignore",
+    ".travis.yml",
+    "bors.toml"
+]
 
 [badges]
 travis-ci = { repository = "dnaq/sodiumoxide" }


### PR DESCRIPTION
Excludes `.gitignores`, `bors.toml`, and `.travis.yml` from the crate.