### PR TITLE
fix std libraries being pulled in even in no_std environments

### DIFF
--- a/libsodium-sys/lib.rs
+++ b/libsodium-sys/lib.rs
@@ -1,4 +1,5 @@
 #![allow(non_upper_case_globals)]
+#![no_std]
 
 extern crate libc;
 use libc::{c_void, c_int, c_ulonglong, c_char, size_t, uint64_t};


### PR DESCRIPTION
Fixes #197 