### PR TITLE
fix std libraries being pulled in even in no_std environments (take 2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,18 +16,18 @@ exclude = [
 ]
 
 [badges]
-travis-ci = { repository = "dnaq/sodiumoxide" }
+travis-ci = { repository = "sodiumoxide/sodiumoxide" }
 
 [dependencies]
-libc = "0.2"
+libc = { version = "^0.2.41" , default-features = false }
 libsodium-sys = { version = "0.0.16", path = "libsodium-sys" }
-serde = { version="1", optional = true }
+serde = { version = "^1.0.59", default-features = false, optional = true }
 
 [dev-dependencies]
-serde = "1"
-serde_json = "1"
-rustc-serialize = "0.3"
-rmp-serde = "0.13"
+serde = "^1.0.59"
+serde_json = "^1.0.17"
+rustc-serialize = "^0.3.24"
+rmp-serde = "^0.13.7"
 
 [features]
 benchmarks = []

--- a/libsodium-sys/Cargo.toml
+++ b/libsodium-sys/Cargo.toml
@@ -12,13 +12,13 @@ categories = ["cryptography", "api-bindings"]
 version = "0.0.16"
 
 [badges]
-travis-ci = { repository = "dnaq/sodiumoxide" }
+travis-ci = { repository = "sodiumoxide/sodiumoxide" }
 
 [build-dependencies]
-pkg-config = "0.3"
+pkg-config = "^0.3.11"
 
 [dependencies]
-libc = "0.2"
+libc = { version = "^0.2.41" , default-features = false }
 
 [lib]
 name = "libsodium_sys"

--- a/libsodium-sys/lib.rs
+++ b/libsodium-sys/lib.rs
@@ -1,4 +1,5 @@
 #![allow(non_upper_case_globals)]
+#![no_std]
 
 extern crate libc;
 use libc::{c_void, c_int, c_ulonglong, c_char, size_t, uint64_t};


### PR DESCRIPTION
Supersedes #213 (I'll leave it up to @kinggoesgaming when/if to close that PR). Fixes #197.

Wanted to make some changes #213 since some of the dependencies in the manifest were still pulling in std.

@Reisen can you test this?