### PR TITLE
Add #[derive(Clone)] to State struct in hash_macros.rs

### DIFF
--- a/src/crypto/hash/hash_macros.rs
+++ b/src/crypto/hash/hash_macros.rs
@@ -31,7 +31,7 @@ pub fn hash(m: &[u8]) -> Digest {
 
 /// `State` contains the state for multi-part (streaming) hash computations. This allows the caller
 /// to process a message as a sequence of multiple chunks.
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub struct State($hash_state);
 
 impl State {

--- a/src/crypto/hash/hash_macros.rs
+++ b/src/crypto/hash/hash_macros.rs
@@ -31,6 +31,7 @@ pub fn hash(m: &[u8]) -> Digest {
 
 /// `State` contains the state for multi-part (streaming) hash computations. This allows the caller
 /// to process a message as a sequence of multiple chunks.
+#[derive(Clone)]
 pub struct State($hash_state);
 
 impl State {


### PR DESCRIPTION
Since `Stream::finalize` takes `mut self` it's not possible to make `Stream` an structure field (e.g. struct `SodiumSha256(sodium_sha256::State)`).
Deriving `Clone` will solve this problem.