### PR TITLE
Instruct OSX users to install pkg-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Dependencies
 
 [Sodium](https://github.com/jedisct1/libsodium) ([installation](https://download.libsodium.org/doc/installation/index.html))
 
+pkg-config (OSX: `brew install pkg-config`)
+
 Building
 --------
     cargo build


### PR DESCRIPTION
```
Failed to run `\"pkg-config\" \"--libs\" \"--cflags\" \"libsodium\"`: No such file or directory (os error 2)"
```

took me a bit of time to figure out `pkg-config` was not available on OSX, versus not being able to find the sodium lib