### PR TITLE
Cargo housekeeping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ exclude = [
     "bors.toml"
 ]
 
+[workspace]
+members = ["libsodium-sys"]
+
 [badges]
 travis-ci = { repository = "sodiumoxide/sodiumoxide" }
 

--- a/libsodium-sys/Cargo.toml
+++ b/libsodium-sys/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "sodiumoxide/sodiumoxide" }
 
 [build-dependencies]
 pkg-config = "^0.3.11"
-bindgen = "0.37.0"
+bindgen = "0.38.0"
 
 [dependencies]
 libc = { version = "^0.2.41" , default-features = false }


### PR DESCRIPTION
- Configure a workspace so sodiumoxide and libsodium-sys share a `target/` instead of creating `target/` and `libsodium-sys/target/`
- Bump the outdated bindgen dependency