### PR TITLE
Update README w/ Clang + Sodium version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ as easy to use.
 Dependencies
 ------------
 
-[Sodium](https://github.com/jedisct1/libsodium) ([installation](https://download.libsodium.org/doc/installation/index.html))
+[Clang](https://clang.llvm.org/) >= 3.9
+
+[Libsodium](https://github.com/jedisct1/libsodium) 1.0.16 ([installation](https://download.libsodium.org/doc/installation))
 
 pkg-config (OSX: `brew install pkg-config`)
 


### PR DESCRIPTION
bindgen recommends Clang >= 3.9 for C++. Earlier versions of libsodium seem not to be building (see #244 and #245), however, the requirement to manually install the latest version if it's not available on your distro is a temporary fix until #234 is merged.