### PR TITLE
Removes duct-taped allow failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ rust:
 - beta
 - nightly
 sudo: false
-matrix:
-  allow_failures:
-  - rust: nightly
 install:
 - wget https://github.com/jedisct1/libsodium/releases/download/1.0.15/libsodium-1.0.15.tar.gz
 - tar xvfz libsodium-1.0.15.tar.gz


### PR DESCRIPTION
We had added allow-failures because of #226. Removing it to revert it back to the old config. 

Resolves: #226 