### PR TITLE
Typo fix in docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 //!  `crypto::sign`
 //!
 //! # Sealed boxes
-//!  `crypto::sealedox`
+//!  `crypto::sealedbox`
 //!
 //! # Secret-key cryptography
 //!  `crypto::secretbox`


### PR DESCRIPTION
This is just an incredibly simple typo fix in the docs.