### PR TITLE
Add Windows support (MSVC)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = ["libsodium-sys"]
 
 [badges]
 travis-ci = { repository = "sodiumoxide/sodiumoxide" }
+appveyor = { repository = "kpp/tox", id = "u05iy6wufw9ncdi7" }
 
 [dependencies]
 libc = { version = "^0.2.41" , default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = ["libsodium-sys"]
 
 [badges]
 travis-ci = { repository = "sodiumoxide/sodiumoxide" }
-appveyor = { repository = "kpp/tox", id = "u05iy6wufw9ncdi7" }
+appveyor = { repository = "Dylan-DPC/sodiumoxide", id = "u05iy6wufw9ncdi7" }
 
 [dependencies]
 libc = { version = "^0.2.41" , default-features = false }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-sodiumoxide
-===========
+# sodiumoxide
 
 [![Build Status](https://travis-ci.org/sodiumoxide/sodiumoxide.svg?branch=master)](https://travis-ci.org/sodiumoxide/sodiumoxide)
 [![Latest Version](https://img.shields.io/crates/v/sodiumoxide.svg)](https://crates.io/crates/sodiumoxide) 
@@ -13,8 +12,7 @@ sodiumoxide
 This package aims to provide a type-safe and efficient Rust binding that's just
 as easy to use.
 
-Dependencies
-------------
+## Dependencies
 
 [Clang](https://clang.llvm.org/) >= 3.9
 
@@ -22,16 +20,16 @@ Dependencies
 
 pkg-config (OSX: `brew install pkg-config`)
 
-Building
---------
+## Building
+
     cargo build
 
-Testing
--------
+## Testing
+
     cargo test
 
-Documentation
--------------
+## Documentation
+
     cargo doc
 
 Documentation will be generated in target/doc/...
@@ -42,8 +40,7 @@ differs between the C and Rust versions.
 Documentation for the latest build can be found at
 [gh-pages](https://sodiumoxide.github.io/sodiumoxide).
 
-Optional features
------------------
+## Optional features
 
 Several [optional features](http://doc.crates.io/manifest.html#usage-in-end-products) are available:
 
@@ -58,40 +55,40 @@ Several [optional features](http://doc.crates.io/manifest.html#usage-in-end-prod
 * `benchmarks` (default: **disabled**). Compile benchmark tests. Requires a
   nightly build of Rust.
 
-Examples
---------
+## Examples
+
 TBD
 
-Platform Compatibiility 
-------------------------
+## Platform Compatibiility 
+
 Sodiumoxide has been tested on: 
 
- Linux -  Yes
+- Linux: Yes
+- Windows: Yes (MSVC) 
+- Mac OS:
+- IOS:
+- Android:
 
- Windows - In Progress 
+### Using vcpkg
 
- Mac OS - `
+To build sodiumoxide using libsodium from vcpkg, you have to add either `VCPKGRS_DYNAMIC=1` (for dynamic linking) or `RUSTFLAGS=-Ctarget-feature=+crt-static` (for static linking) to environment variables.
 
- IOS -
+Regardless of the OS, to link libsodium statically you also need to set `SODIUM_STATIC` environment variable.
 
- Android -
+# Join in
 
-
-Join in
-=======
 File bugs in the issue tracker
 
 Master git repository
 
     git clone https://github.com/sodiumoxide/sodiumoxide.git
 
-License
--------
+## License
 
 Licensed under either of
 
- * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 at your option.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # sodiumoxide
 
 [![Build Status](https://travis-ci.org/sodiumoxide/sodiumoxide.svg?branch=master)](https://travis-ci.org/sodiumoxide/sodiumoxide)
+[![Appveyor Build Status][appveyor-badge]][appveyor-url]
 [![Latest Version](https://img.shields.io/crates/v/sodiumoxide.svg)](https://crates.io/crates/sodiumoxide) 
 [![Join the chat at https://gitter.im/rust-sodiumoxide/Lobby](https://badges.gitter.im/rust-sodiumoxide/Lobby.svg)](https://gitter.im/rust-sodiumoxide/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+[appveyor-badge]: https://ci.appveyor.com/api/projects/status/u05iy6wufw9ncdi7/branch/master?svg=true
+[appveyor-url]: https://ci.appveyor.com/project/Dylan-DPC/sodiumoxide/branch/master
 
 > [NaCl](http://nacl.cr.yp.to) (pronounced "salt") is a new easy-to-use high-speed software library for network communication, encryption, decryption, signatures, etc. NaCl's goal is to provide all of the core operations needed to build higher-level cryptographic tools.
 > Of course, other libraries already exist for these core operations. NaCl advances the state of the art by improving security, by improving usability, and by improving speed.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,62 @@
+image: Visual Studio 2017
+
+environment:
+  VCPKGRS_DYNAMIC: 1
+  LLVM_VERSION: 6.0.1
+  matrix:
+  - TARGET: x86_64-pc-windows-msvc
+    VCPKG_TARGET: x64-windows
+    RUST_CHANNEL: stable
+    LLVM_TARGET: win64
+
+  - TARGET: i686-pc-windows-msvc
+    VCPKG_TARGET: x86-windows
+    RUST_CHANNEL: stable
+    LLVM_TARGET: win32
+
+  - TARGET: x86_64-pc-windows-msvc
+    VCPKG_TARGET: x64-windows
+    RUST_CHANNEL: beta
+    LLVM_TARGET: win64
+
+  - TARGET: i686-pc-windows-msvc
+    VCPKG_TARGET: x86-windows
+    RUST_CHANNEL: beta
+    LLVM_TARGET: win32
+
+  - TARGET: x86_64-pc-windows-msvc
+    VCPKG_TARGET: x64-windows
+    RUST_CHANNEL: nightly
+    LLVM_TARGET: win64
+
+  - TARGET: i686-pc-windows-msvc
+    VCPKG_TARGET: x86-windows
+    RUST_CHANNEL: nightly
+    LLVM_TARGET: win32
+
+install:
+  - ps: |
+      # Install Rust
+      appveyor-retry appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+      cmd.exe /c .\rustup-init.exe -y --default-host "$env:TARGET" --default-toolchain "$env:RUST_CHANNEL" 2`>`&1
+      $env:PATH += ";$env:USERPROFILE\.cargo\bin"
+
+      # Install LLVM
+      echo "LLVM-${env:LLVM_VERSION}-${env:LLVM_TARGET}"
+      appveyor-retry appveyor DownloadFile "http://releases.llvm.org/${env:LLVM_VERSION}/LLVM-${env:LLVM_VERSION}-${env:LLVM_TARGET}.exe" -FileName llvm-installer.exe
+      7z x llvm-installer.exe -oc:\llvm-binary
+      #$env:PATH += ";C:\llvm-binary\bin"
+      $env:LIBCLANG_PATH = "C:\llvm-binary\bin"
+
+      # Install libsodium
+      vcpkg install "libsodium:$env:VCPKG_TARGET"
+
+cache:
+  - C:\Users\appveyor\.cargo\registry
+  - target
+
+build_script:
+  - cmd: cargo build --target %TARGET%
+
+test_script:
+  - cmd: cargo test --target %TARGET%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,7 +45,6 @@ install:
       echo "LLVM-${env:LLVM_VERSION}-${env:LLVM_TARGET}"
       appveyor-retry appveyor DownloadFile "http://releases.llvm.org/${env:LLVM_VERSION}/LLVM-${env:LLVM_VERSION}-${env:LLVM_TARGET}.exe" -FileName llvm-installer.exe
       7z x llvm-installer.exe -oc:\llvm-binary
-      #$env:PATH += ";C:\llvm-binary\bin"
       $env:LIBCLANG_PATH = "C:\llvm-binary\bin"
 
       # Install libsodium

--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,4 @@
 status = [
 	"continuous-integration/travis-ci/push",
+	"continuous-integration/appveyor/branch"
 ]

--- a/libsodium-sys/Cargo.toml
+++ b/libsodium-sys/Cargo.toml
@@ -18,6 +18,9 @@ travis-ci = { repository = "sodiumoxide/sodiumoxide" }
 pkg-config = "^0.3.11"
 bindgen = "0.38.0"
 
+[target.'cfg(target_env = "msvc")'.build-dependencies]
+vcpkg = "0.2"
+
 [dependencies]
 libc = { version = "^0.2.41" , default-features = false }
 

--- a/libsodium-sys/build.rs
+++ b/libsodium-sys/build.rs
@@ -4,31 +4,25 @@ extern crate pkg_config;
 use std::env;
 use std::path::PathBuf;
 
+#[cfg(target_env = "msvc")]
+extern crate vcpkg;
+
 fn main() {
     println!("cargo:rerun-if-env-changed=SODIUM_LIB_DIR");
     println!("cargo:rerun-if-env-changed=SODIUM_INC_DIR");
     println!("cargo:rerun-if-env-changed=SODIUM_STATIC");
 
-    if let Ok(lib_dir) = env::var("SODIUM_LIB_DIR") {
-        println!("cargo:rustc-link-search=native={}", lib_dir);
-
-        let mode = match env::var_os("SODIUM_STATIC") {
-            Some(_) => "static",
-            None => "dylib",
-        };
-        if cfg!(target_env = "msvc") {
-            println!("cargo:rustc-link-lib={0}=libsodium", mode);
-        } else {
-            println!("cargo:rustc-link-lib={0}=sodium", mode);
-        }
+    let mode = match env::var_os("SODIUM_STATIC") {
+        Some(_) => "static",
+        None => "dylib",
+    };
+    if cfg!(target_env = "msvc") {
+        println!("cargo:rustc-link-lib={0}=libsodium", mode);
     } else {
-        pkg_config::find_library("libsodium").unwrap();
+        println!("cargo:rustc-link-lib={0}=sodium", mode);
     }
 
-    let include_dir = match env::var("SODIUM_INC_DIR") {
-        Ok(dir) => dir,
-        Err(_) => pkg_config::get_variable("libsodium", "includedir").unwrap()
-    };
+    let include_dir = find_libsodium();
 
     let bindings = bindgen::Builder::default()
         .header("sodium_wrapper.h")
@@ -44,4 +38,54 @@ fn main() {
     bindings
         .write_to_file(out_path.join("sodium_bindings.rs"))
         .expect("Couldn't write bindings!");
+}
+
+#[cfg(target_env = "msvc")]
+fn find_libsodium() -> String {
+    if let Ok(lib_dir) = env::var("SODIUM_LIB_DIR") {
+        println!("cargo:rustc-link-search=native={}", lib_dir);
+    } else {
+        if !try_vcpkg() {
+            panic!("Could not find libsodium on this system!")
+        }
+    }
+
+    let include_dir =
+        env::var("SODIUM_INC_DIR").ok()
+        .or_else(get_vcpkg_include_path).unwrap();
+
+    include_dir
+}
+
+#[cfg(not(target_env = "msvc"))]
+fn find_libsodium() -> String {
+    if let Ok(lib_dir) = env::var("SODIUM_LIB_DIR") {
+        println!("cargo:rustc-link-search=native={}", lib_dir);
+    } else {
+        pkg_config::find_library("libsodium").unwrap();
+    }
+
+    let include_dir =
+        env::var("SODIUM_INC_DIR")
+        .or_else(|_| pkg_config::get_variable("libsodium", "includedir")).unwrap();
+
+    include_dir
+}
+
+#[cfg(target_env = "msvc")]
+fn try_vcpkg() -> bool {
+    vcpkg::Config::new()
+        .lib_name("libsodium")
+        .probe("libsodium")
+        .is_ok() || vcpkg::probe_package("libsodium").is_ok()
+}
+
+
+#[cfg(target_env = "msvc")]
+fn get_vcpkg_include_path() -> Option<String> {
+    let lib = vcpkg::probe_package("libsodium");
+    match lib {
+        Ok(lib) => lib.include_paths.get(0).and_then(|path| path.clone().into_os_string().into_string().ok()),
+        _ => None,
+    }
 }


### PR DESCRIPTION
NB: vcpkg-rs requires some environment variables to be set, and these variables cannot be set in `build.rs`.