### PR TITLE
Fix redundant linker flag specified for library `sodium`

### DIFF
--- a/libsodium-sys/build.rs
+++ b/libsodium-sys/build.rs
@@ -62,7 +62,8 @@ fn find_libsodium() -> String {
         println!("cargo:rustc-link-lib={0}=sodium", mode);
         println!("cargo:rustc-link-search=native={}", lib_dir);
     } else {
-        pkg_config::find_library("libsodium").unwrap();
+        let statik = env::var_os("SODIUM_STATIC").is_some();
+        pkg_config::Config::new().statik(statik).find("libsodium").unwrap();
     }
 
     let include_dir =

--- a/libsodium-sys/build.rs
+++ b/libsodium-sys/build.rs
@@ -12,16 +12,6 @@ fn main() {
     println!("cargo:rerun-if-env-changed=SODIUM_INC_DIR");
     println!("cargo:rerun-if-env-changed=SODIUM_STATIC");
 
-    let mode = match env::var_os("SODIUM_STATIC") {
-        Some(_) => "static",
-        None => "dylib",
-    };
-    if cfg!(target_env = "msvc") {
-        println!("cargo:rustc-link-lib={0}=libsodium", mode);
-    } else {
-        println!("cargo:rustc-link-lib={0}=sodium", mode);
-    }
-
     let include_dir = find_libsodium();
 
     let bindings = bindgen::Builder::default()
@@ -43,6 +33,11 @@ fn main() {
 #[cfg(target_env = "msvc")]
 fn find_libsodium() -> String {
     if let Ok(lib_dir) = env::var("SODIUM_LIB_DIR") {
+        let mode = match env::var_os("SODIUM_STATIC") {
+            Some(_) => "static",
+            None => "dylib",
+        };
+        println!("cargo:rustc-link-lib={0}=libsodium", mode);
         println!("cargo:rustc-link-search=native={}", lib_dir);
     } else {
         if !try_vcpkg() {
@@ -60,6 +55,11 @@ fn find_libsodium() -> String {
 #[cfg(not(target_env = "msvc"))]
 fn find_libsodium() -> String {
     if let Ok(lib_dir) = env::var("SODIUM_LIB_DIR") {
+        let mode = match env::var_os("SODIUM_STATIC") {
+            Some(_) => "static",
+            None => "dylib",
+        };
+        println!("cargo:rustc-link-lib={0}=sodium", mode);
         println!("cargo:rustc-link-search=native={}", lib_dir);
     } else {
         pkg_config::find_library("libsodium").unwrap();


### PR DESCRIPTION
Close #273 


```
$ cargo build
   Compiling libsodium-sys v0.1.0 (/home/USER/sodiumoxide/libsodium-sys)
   Compiling sodiumoxide v0.1.0 (/home/USER/sodiumoxide)
warning: unused macro definition
   --> src/crypto/onetimeauth/../auth/auth_macros.rs:172:1
    |
172 | / macro_rules! auth_state (($state_name:ident,
173 | |                           $init_name:ident,
174 | |                           $update_name:ident,
175 | |                           $final_name:ident,
...   |
268 | | }
269 | | ));
    | |___^
    |
    = note: #[warn(unused_macros)] on by default

    Finished dev [unoptimized + debuginfo] target(s) in 7.27s
```