### PR TITLE
Fix build on Win using vcpkg

### DIFF
--- a/libsodium-sys/build.rs
+++ b/libsodium-sys/build.rs
@@ -11,6 +11,10 @@ fn main() {
     println!("cargo:rerun-if-env-changed=SODIUM_LIB_DIR");
     println!("cargo:rerun-if-env-changed=SODIUM_INC_DIR");
     println!("cargo:rerun-if-env-changed=SODIUM_STATIC");
+    if cfg!(target_env = "msvc") {
+        // vcpkg requires to set env VCPKGRS_DYNAMIC
+        println!("cargo:rerun-if-env-changed=VCPKGRS_DYNAMIC");
+    }
 
     let include_dir = find_libsodium();
 

--- a/libsodium-sys/build.rs
+++ b/libsodium-sys/build.rs
@@ -16,7 +16,15 @@ fn main() {
         println!("cargo:rerun-if-env-changed=VCPKGRS_DYNAMIC");
     }
 
-    let include_dir = find_libsodium();
+    let include_dir = {
+        let lib_dir_isset = env::var_os("SODIUM_LIB_DIR").is_some();
+        let inc_dir_isset = env::var_os("SODIUM_INC_DIR").is_some();
+        if lib_dir_isset || inc_dir_isset {
+            find_libsodium_env()
+        } else {
+            find_libsodium_pkg()
+        }
+    };
 
     let bindings = bindgen::Builder::default()
         .header("sodium_wrapper.h")
@@ -34,63 +42,55 @@ fn main() {
         .expect("Couldn't write bindings!");
 }
 
-#[cfg(target_env = "msvc")]
-fn find_libsodium() -> String {
-    if let Ok(lib_dir) = env::var("SODIUM_LIB_DIR") {
-        let mode = match env::var_os("SODIUM_STATIC") {
-            Some(_) => "static",
-            None => "dylib",
-        };
+
+/* Must be called when SODIUM_LIB_DIR or SODIUM_INC_DIR is set to any value
+This function will set `cargo` flags.
+Return: SODIUM_INC_DIR
+*/
+fn find_libsodium_env() -> String {
+    let lib_dir = env::var("SODIUM_LIB_DIR")
+        .expect("SODIUM_LIB_DIR must be set because SODIUM_INC_DIR is set. Error");
+    let inc_dir = env::var("SODIUM_INC_DIR")
+        .expect("SODIUM_INC_DIR must be set because SODIUM_LIB_DIR is set. Error");
+
+    let mode = match env::var_os("SODIUM_STATIC") {
+        Some(_) => "static",
+        None => "dylib",
+    };
+
+    if cfg!(target_env = "msvc") {
         println!("cargo:rustc-link-lib={0}=libsodium", mode);
-        println!("cargo:rustc-link-search=native={}", lib_dir);
     } else {
-        if !try_vcpkg() {
-            panic!("Could not find libsodium on this system!")
-        }
-    }
-
-    let include_dir =
-        env::var("SODIUM_INC_DIR").ok()
-        .or_else(get_vcpkg_include_path).unwrap();
-
-    include_dir
-}
-
-#[cfg(not(target_env = "msvc"))]
-fn find_libsodium() -> String {
-    if let Ok(lib_dir) = env::var("SODIUM_LIB_DIR") {
-        let mode = match env::var_os("SODIUM_STATIC") {
-            Some(_) => "static",
-            None => "dylib",
-        };
         println!("cargo:rustc-link-lib={0}=sodium", mode);
-        println!("cargo:rustc-link-search=native={}", lib_dir);
-    } else {
-        let statik = env::var_os("SODIUM_STATIC").is_some();
-        pkg_config::Config::new().statik(statik).find("libsodium").unwrap();
     }
+    println!("cargo:rustc-link-search=native={}", lib_dir);
 
-    let include_dir =
-        env::var("SODIUM_INC_DIR")
-        .or_else(|_| pkg_config::get_variable("libsodium", "includedir")).unwrap();
-
-    include_dir
+    inc_dir
 }
 
+/* Must be called when no SODIUM_LIB_DIR and no SODIUM_INC_DIR env vars are set
+This function will set `cargo` flags.
+Return: the first include path from vcpkg
+*/
 #[cfg(target_env = "msvc")]
-fn try_vcpkg() -> bool {
-    vcpkg::Config::new()
-        .lib_name("libsodium")
-        .probe("libsodium")
-        .is_ok() || vcpkg::probe_package("libsodium").is_ok()
+fn find_libsodium_pkg() -> String {
+    let lib = vcpkg::probe_package("libsodium")
+        .expect("Could not find libsodium on this system");
+    let include_dir = lib.include_paths.get(0)
+        .expect("Could not get includedir using vcpkg");
+    include_dir.clone().into_os_string().into_string().ok()
+        .expect("Could not get cast include_dir to String")
 }
 
-
-#[cfg(target_env = "msvc")]
-fn get_vcpkg_include_path() -> Option<String> {
-    let lib = vcpkg::probe_package("libsodium");
-    match lib {
-        Ok(lib) => lib.include_paths.get(0).and_then(|path| path.clone().into_os_string().into_string().ok()),
-        _ => None,
-    }
+/* Must be called when no SODIUM_LIB_DIR and no SODIUM_INC_DIR env vars are set
+This function will set `cargo` flags.
+Return: includedir from pkg-config
+*/
+#[cfg(not(target_env = "msvc"))]
+fn find_libsodium_pkg() -> String {
+    let statik = env::var_os("SODIUM_STATIC").is_some();
+    pkg_config::Config::new().statik(statik).probe("libsodium")
+        .expect("Could not find libsodium on this system");
+    pkg_config::get_variable("libsodium", "includedir")
+        .expect("Could not get includedir using pkg-config")
 }


### PR DESCRIPTION
1. Don't call to pkg-config or vcpkg if 1 of SODIUM_LIB_DIR or SODIUM_INC_DIR is set
2. Fix redundant linker flag specified for library `sodium` (This time for Win 10)
3. Add VCPKGRS_DYNAMIC to rerun-if-env-changed on Win systems, because vcpkg will fail if there is no such env var
4. Print full error message instead of "Could not find libsodium on this system"