### PR TITLE
Removed unnecessary dev-dependency on quickcheck

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ serde = "^1.0.59"
 serde_json = "^1.0.17"
 rustc-serialize = "^0.3.24"
 rmp-serde = "^0.13.7"
-quickcheck = "^0.6.2"
 
 [features]
 benchmarks = []

--- a/src/crypto/verify.rs
+++ b/src/crypto/verify.rs
@@ -70,47 +70,6 @@ mod test {
         }
     }
 
-    quickcheck! {
-        fn qc_verify_16(diff: Vec<usize>) -> bool {
-            use randombytes::randombytes_into;
-
-            ({ // no diff
-                let mut x = [0; 16];
-                let mut y = [0; 16];
-
-                assert!(verify_16(&x, &y));
-                assert!(verify_16(&y, &x));
-
-                randombytes_into(&mut x);
-                y = x;
-
-                verify_16(&x, &y) && verify_16(&y, &x)
-            })
-                &&
-                ({ // add diff according to provided vector
-                    let mut x = [0; 16];
-                    let mut y = [0; 16];
-
-                    assert!(verify_16(&x, &y));
-                    assert!(verify_16(&y, &x));
-
-                    randombytes_into(&mut x);
-                    y = x;
-
-                    for i in &diff[..] {
-                        let i = i % 16;
-                        y[i] = y[i].wrapping_add(1);
-                    }
-
-                    if x == y {
-                        verify_16(&x, &y) && verify_16(&y, &x)
-                    } else {
-                        !verify_16(&x, &y) && !verify_16(&y, &x)
-                    }
-                })
-        }
-    }
-
     #[test]
     fn test_verify_32() {
         use randombytes::randombytes_into;
@@ -126,47 +85,6 @@ mod test {
             } else {
                 assert!(!verify_32(&x, &y))
             }
-        }
-    }
-
-    quickcheck! {
-        fn qc_verify_32(diff: Vec<usize>) -> bool {
-            use randombytes::randombytes_into;
-
-            ({ // no diff
-                let mut x = [0; 32];
-                let mut y = [0; 32];
-
-                assert!(verify_32(&x, &y));
-                assert!(verify_32(&y, &x));
-
-                randombytes_into(&mut x);
-                y = x;
-
-                verify_32(&x, &y) && verify_32(&y, &x)
-            })
-                &&
-                ({ // add diff according to provided vector
-                    let mut x = [0; 32];
-                    let mut y = [0; 32];
-
-                    assert!(verify_32(&x, &y));
-                    assert!(verify_32(&y, &x));
-
-                    randombytes_into(&mut x);
-                    y = x;
-
-                    for i in &diff[..] {
-                        let i = i % 32;
-                        y[i] = y[i].wrapping_add(1);
-                    }
-
-                    if x == y {
-                        verify_32(&x, &y) && verify_32(&y, &x)
-                    } else {
-                        !verify_32(&x, &y) && !verify_32(&y, &x)
-                    }
-                })
         }
     }
 
@@ -188,51 +106,4 @@ mod test {
         }
     }
 
-    quickcheck! {
-        fn qc_verify_64(diff: Vec<usize>) -> bool {
-            use randombytes::randombytes_into;
-
-            ({ // no diff
-                let mut x = [0; 64];
-                let mut y = [0; 64];
-
-                assert!(verify_64(&x, &y));
-                assert!(verify_64(&y, &x));
-
-                randombytes_into(&mut x);
-                y = x;
-
-                verify_64(&x, &y) && verify_64(&y, &x)
-            })
-                &&
-                ({ // add diff according to provided vector
-                    let mut x = [0; 64];
-                    let mut y = [0; 64];
-
-                    assert!(verify_64(&x, &y));
-                    assert!(verify_64(&y, &x));
-
-                    randombytes_into(&mut x);
-                    y = x;
-
-                    for i in &diff[..] {
-                        let i = i % 64;
-                        y[i] = y[i].wrapping_add(1);
-                    }
-
-                    let mut same = true;
-                    for i in 0..64 {
-                        if x[i] != y[i] {
-                            same = false;
-                        }
-                    }
-
-                    if same {
-                        verify_64(&x, &y) && verify_64(&y, &x)
-                    } else {
-                        !verify_64(&x, &y) && !verify_64(&y, &x)
-                    }
-                })
-        }
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,10 +69,6 @@ extern crate alloc;
 #[cfg(all(test, not(feature = "std")))]
 extern crate std;
 
-#[cfg(test)]
-#[macro_use]
-extern crate quickcheck;
-
 #[cfg(all(not(test), not(feature = "std")))]
 mod std {
     pub use core::{cmp, fmt, hash, iter, mem, ops, ptr, slice, str};


### PR DESCRIPTION
This dependency was only used for the tests for `verify32` and
`verify64` and the tests didn't test anything that wasn't already
tested.