### PR TITLE
Add support for systems that output the pinned libsodium to lib64

### DIFF
--- a/libsodium-sys/build.rs
+++ b/libsodium-sys/build.rs
@@ -494,4 +494,5 @@ fn build_libsodium() {
 
     println!("cargo:rustc-link-lib=static=sodium");
     println!("cargo:rustc-link-search=native={}/lib", install_dir);
+    println!("cargo:rustc-link-search=native={}/lib64", install_dir);
 }


### PR DESCRIPTION
Building sodiumoxide on OpenSUSE Tumbleweed as of 2018/12/18 causes the build of the pinned libsodium library to fail.

This is caused by build.rs presuming the library to be output in the `lib` directory, while the actual output directory is `lib64`. 
```
     Running `/home/elyzion/.cargo/bin/sccache rustc --crate-name libsodium_sys libsodium-sys/src/lib.rs --color always --crate-type lib --emit=dep-info,link -C debuginfo=2 -C metadata=43c000b33b9ab959 -C extra-filename=-43c000b33b9ab959 --out-dir /home/elyzion/workspace/github.com/elyzion/sodiumoxide/target/debug/deps -C incremental=/home/elyzion/workspace/github.com/elyzion/sodiumoxide/target/debug/incremental -L dependency=/home/elyzion/workspace/github.com/elyzion/sodiumoxide/target/debug/deps --extern libc=/home/elyzion/workspace/github.com/elyzion/sodiumoxide/target/debug/deps/liblibc-c0ea49ff27a168b5.rlib -L native=/home/elyzion/workspace/github.com/elyzion/sodiumoxide/target/debug/build/libsodium-sys-21cd69d46e7fda91/out/installed/lib -l static=sodium`
error: could not find native static library `sodium`, perhaps an -L flag is missing?

error: aborting due to previous error

error: Could not compile `libsodium-sys`.
```

This is a quick solution to this problem that simple adds another search path for cargo.