### PR TITLE
WIP libsodium submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "libsodium-sys/libsodium"]
 	path = libsodium-sys/libsodium
-	url = git@github.com:jedisct1/libsodium.git
-	tag = 1.0.16
+	url = https://github.com/jedisct1/libsodium.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "libsodium-sys/libsodium"]
+	path = libsodium-sys/libsodium
+	url = git@github.com:jedisct1/libsodium.git
+	tag = 1.0.16

--- a/libsodium-sys/Cargo.toml
+++ b/libsodium-sys/Cargo.toml
@@ -15,17 +15,13 @@ version = "0.2.0"
 travis-ci = { repository = "sodiumoxide/sodiumoxide" }
 
 [build-dependencies]
-cc = "1.0.9"
-flate2 = "1.0.1"
-http_req = "0.2.1"
-pkg-config = "0.3.11"
-libc = { version = "0.2.41" , default-features = false }
-sha2 = "0.8"
-tar = "0.4.15"
-zip = "0.5"
+cc = { version = "1.0" }
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]
 vcpkg = "0.2"
+
+[target.'cfg(not(target_env = "msvc"))'.build-dependencies]
+pkg-config = "0.3.11"
 
 [dependencies]
 libc = { version = "^0.2.41" , default-features = false }

--- a/libsodium-sys/build.rs
+++ b/libsodium-sys/build.rs
@@ -8,9 +8,9 @@ extern crate vcpkg;
 
 use std::env;
 use std::fs;
-use std::str;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::str;
 
 static VERSION: &'static str = "1.0.16";
 
@@ -131,14 +131,13 @@ fn get_install_dir() -> PathBuf {
     PathBuf::from(env::var("OUT_DIR").unwrap()).join("installed/")
 }
 
-
 fn build_libsodium() {
-
     // Download sources
     let source_dir = get_cur_dir().join("libsodium/");
     if !source_dir.join(".git").exists() {
-        let _ = Command::new("git").args(&["submodule", "update", "--init"])
-                                   .status();
+        let _ = Command::new("git")
+            .args(&["submodule", "update", "--init"])
+            .status();
     }
 
     // Determine build target triple
@@ -345,5 +344,8 @@ fn build_libsodium() {
     }
 
     println!("cargo:rustc-link-lib=static=sodium");
-    println!("cargo:rustc-link-search=native={}/lib", install_dir.display());
+    println!(
+        "cargo:rustc-link-search=native={}/lib",
+        install_dir.display()
+    );
 }


### PR DESCRIPTION
Don't download libsodium artifacts. Build it from source!

TODO: sometimes `cargo build` fails if you rebuild the project. Repeat `cargo build` and it will be build. Weird.

Profit:
```
~/sodiumoxide$ cargo tree
sodiumoxide v0.2.0 (/home/humbug/sodiumoxide)                                                                                                        
├── libc v0.2.45
├── libsodium-sys v0.2.0 (/home/humbug/sodiumoxide/libsodium-sys)
│   └── libc v0.2.45 (*)
│   [build-dependencies]
│   ├── cc v1.0.28
│   └── pkg-config v0.3.14
└── serde v1.0.82
[dev-dependencies]
├── rmp-serde v0.13.7
│   ├── byteorder v1.2.7
│   ├── rmp v0.8.7
│   │   ├── byteorder v1.2.7 (*)
│   │   └── num-traits v0.1.43
│   │       └── num-traits v0.2.6
│   └── serde v1.0.82 (*)
├── rustc-serialize v0.3.24
├── serde v1.0.82 (*)
└── serde_json v1.0.33
    ├── itoa v0.4.3
    ├── ryu v0.2.7
    └── serde v1.0.82 (*)
```