### PR TITLE
Fix struct alignments that are not correctly recognized by bindgen

### DIFF
--- a/libsodium-sys/src/alignment_fix.patch
+++ b/libsodium-sys/src/alignment_fix.patch
@@ -1,0 +1,30 @@
+diff --git a/libsodium-sys/src/sodium_bindings.rs b/libsodium-sys/src/sodium_bindings.rs
+index 06b0fc76..c2d61b28 100644
+--- a/libsodium-sys/src/sodium_bindings.rs
++++ b/libsodium-sys/src/sodium_bindings.rs
+@@ -1454,7 +1454,7 @@ extern "C" {
+         c: *const libc::c_uchar,
+     ) -> libc::c_int;
+ }
+-#[repr(C)]
++#[repr(C, align(64))]
+ #[derive(Copy, Clone)]
+ pub struct crypto_generichash_blake2b_state {
+     pub h: [u64; 8usize],
+@@ -1463,7 +1463,6 @@ pub struct crypto_generichash_blake2b_state {
+     pub buf: [u8; 256usize],
+     pub buflen: usize,
+     pub last_node: u8,
+-    pub __bindgen_padding_0: [u8; 23usize],
+ }
+ #[test]
+ fn bindgen_test_layout_crypto_generichash_blake2b_state() {
+@@ -1795,7 +1794,7 @@ extern "C" {
+         client_pk: *const libc::c_uchar,
+     ) -> libc::c_int;
+ }
+-#[repr(C)]
++#[repr(C, align(16))]
+ #[derive(Copy, Clone)]
+ pub struct crypto_onetimeauth_poly1305_state {
+     pub opaque: [libc::c_uchar; 256usize],

--- a/libsodium-sys/src/gen.sh
+++ b/libsodium-sys/src/gen.sh
@@ -9,3 +9,11 @@ bindgen PATH_TO/libsodium-1.0.16/src/libsodium/include/sodium.h -o sodium_bindin
   --whitelist-function=$REGEX \
   --whitelist-type=$REGEX \
   --whitelist-var=$REGEX
+
+# bindgen fails to compute the alignment in some cases:
+# - the alignment of crypto_onetimeauth_poly1305_state should be 16
+#   see https://github.com/jedisct1/libsodium/blob/1.0.16/src/libsodium/include/sodium/crypto_onetimeauth_poly1305.h#L19
+# - the alignment of crypto_generichash_blake2b_state should be 64
+#   see https://github.com/jedisct1/libsodium/blob/1.0.16/src/libsodium/include/sodium/crypto_generichash_blake2b.h#L23
+# the patch below fixes this
+git apply alignment_fix.patch

--- a/libsodium-sys/src/sodium_bindings.rs
+++ b/libsodium-sys/src/sodium_bindings.rs
@@ -1454,7 +1454,7 @@ extern "C" {
         c: *const libc::c_uchar,
     ) -> libc::c_int;
 }
-#[repr(C)]
+#[repr(C, align(64))]
 #[derive(Copy, Clone)]
 pub struct crypto_generichash_blake2b_state {
     pub h: [u64; 8usize],
@@ -1463,7 +1463,6 @@ pub struct crypto_generichash_blake2b_state {
     pub buf: [u8; 256usize],
     pub buflen: usize,
     pub last_node: u8,
-    pub __bindgen_padding_0: [u8; 23usize],
 }
 #[test]
 fn bindgen_test_layout_crypto_generichash_blake2b_state() {
@@ -1795,7 +1794,7 @@ extern "C" {
         client_pk: *const libc::c_uchar,
     ) -> libc::c_int;
 }
-#[repr(C)]
+#[repr(C, align(16))]
 #[derive(Copy, Clone)]
 pub struct crypto_onetimeauth_poly1305_state {
     pub opaque: [libc::c_uchar; 256usize],

--- a/libsodium-sys/tests/crypto/crypto_generichash_blake2b.rs
+++ b/libsodium-sys/tests/crypto/crypto_generichash_blake2b.rs
@@ -3,6 +3,12 @@
 use libsodium_sys::*;
 
 #[test]
+fn test_crypto_generichash_blake2b_state_alignment() {
+    // this asserts the alignment applied in alignment_fix.patch (see gen.sh)
+    assert_eq!(64, std::mem::align_of::<crypto_generichash_blake2b_state>());
+}
+
+#[test]
 fn test_crypto_generichash_blake2b_bytes_min() {
     assert_eq!(
         unsafe { crypto_generichash_blake2b_bytes_min() },

--- a/libsodium-sys/tests/crypto/crypto_onetimeauth_poly1305.rs
+++ b/libsodium-sys/tests/crypto/crypto_onetimeauth_poly1305.rs
@@ -3,6 +3,15 @@
 use libsodium_sys::*;
 
 #[test]
+fn test_crypto_onetimeauth_poly1305_state_alignment() {
+    // this asserts the alignment applied in alignment_fix.patch (see gen.sh)
+    assert_eq!(
+        16,
+        std::mem::align_of::<crypto_onetimeauth_poly1305_state>()
+    );
+}
+
+#[test]
 fn test_crypto_onetimeauth_poly1305_bytes() {
     assert!(
         unsafe { crypto_onetimeauth_poly1305_bytes() }


### PR DESCRIPTION
@kpp @Fraser999 I've applied the comments from #303 and put them into a new PR. This now includes patching `crypto_onetimeauth_poly1305_state` and adding the tests to `libsodium-sys`. 

Anything I missed 😊?