### PR TITLE
Add convenience functions for pwhash() and derive_key()

### DIFF
--- a/src/crypto/pwhash/scryptsalsa208sha256.rs
+++ b/src/crypto/pwhash/scryptsalsa208sha256.rs
@@ -129,7 +129,13 @@ pub fn derive_key_interactive<'a>(
     passwd: &[u8],
     salt: &Salt,
 ) -> Result<&'a [u8], ()> {
-    derive_key(key, passwd, salt, OPSLIMIT_INTERACTIVE, MEMLIMIT_INTERACTIVE)
+    derive_key(
+        key,
+        passwd,
+        salt,
+        OPSLIMIT_INTERACTIVE,
+        MEMLIMIT_INTERACTIVE,
+    )
 }
 
 /// `derive_key_sensitive()` is a shortcut function for `derive_key()` with
@@ -140,13 +146,7 @@ pub fn derive_key_sensitive<'a>(
     passwd: &[u8],
     salt: &Salt,
 ) -> Result<&'a [u8], ()> {
-    derive_key(
-        key,
-        passwd,
-        salt,
-        OPSLIMIT_SENSITIVE,
-        MEMLIMIT_SENSITIVE,
-    )
+    derive_key(key, passwd, salt, OPSLIMIT_SENSITIVE, MEMLIMIT_SENSITIVE)
 }
 
 /// The `pwhash()` returns a `HashedPassword` which

--- a/src/crypto/pwhash/scryptsalsa208sha256.rs
+++ b/src/crypto/pwhash/scryptsalsa208sha256.rs
@@ -124,6 +124,34 @@ pub fn derive_key<'a>(
     }
 }
 
+/// `derive_key_interactive()` is a shortcut function for `derive_key()` with
+/// interactive limits (i.e. using `derive_key()` with `OPSLIMIT_INTERACTIVE`
+/// and `MEMLIMIT_INTERACTIVE`)
+pub fn derive_key_interactive<'a>(
+    key: &'a mut [u8],
+    passwd: &[u8],
+    salt: &Salt,
+) -> Result<&'a [u8], ()> {
+    derive_key(key, passwd, salt, OPSLIMIT_INTERACTIVE, MEMLIMIT_INTERACTIVE)
+}
+
+/// `derive_key_sensitive()` is a shortcut function for `derive_key()` with
+/// sensitive limits (i.e. using `derive_key()` with `OPSLIMIT_SENSITIVE`
+/// and `MEMLIMIT_SENSITIVE`)
+pub fn derive_key_sensitive<'a>(
+    key: &'a mut [u8],
+    passwd: &[u8],
+    salt: &Salt,
+) -> Result<&'a [u8], ()> {
+    derive_key(
+        key,
+        passwd,
+        salt,
+        OPSLIMIT_SENSITIVE,
+        MEMLIMIT_SENSITIVE,
+    )
+}
+
 /// The `pwhash()` returns a `HashedPassword` which
 /// includes:
 ///
@@ -158,6 +186,20 @@ pub fn pwhash(
     } else {
         Err(())
     }
+}
+
+/// `pwhash_interactive()` is a shortcut function for `pwhash()` with
+/// interactive limits (i.e. using `pwhash()` with `OPSLIMIT_INTERACTIVE`
+/// and `MEMLIMIT_INTERACTIVE`)
+pub fn pwhash_interactive(passwd: &[u8]) -> Result<HashedPassword, ()> {
+    pwhash(passwd, OPSLIMIT_INTERACTIVE, MEMLIMIT_INTERACTIVE)
+}
+
+/// `pwhash_sensitive()` is a shortcut function for `pwhash()` with
+/// sensitive limits (i.e. using `pwhash()` with `OPSLIMIT_SENSITIVE`
+/// and `MEMLIMIT_SENSITIVE`)
+pub fn pwhash_sensitive(passwd: &[u8]) -> Result<HashedPassword, ()> {
+    pwhash(passwd, OPSLIMIT_SENSITIVE, MEMLIMIT_SENSITIVE)
 }
 
 /// `pwhash_verify()` verifies that the password `str_` is a valid password


### PR DESCRIPTION
The limit arguments in pwhash() and derive_key() with its two parameters is a bit "loud" with its two (for most users) constant parameters. This adds two convenience functions for both.