### PR TITLE
Add use-pkg-config feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,4 @@ rmp-serde = "^0.13.7"
 benchmarks = []
 std = []
 default = ["serde", "std"]
+use-pkg-config = ["libsodium-sys/use-pkg-config"]

--- a/libsodium-sys/Cargo.toml
+++ b/libsodium-sys/Cargo.toml
@@ -36,3 +36,6 @@ libc = { version = "=0.2.48" , default-features = false }
 
 [lib]
 name = "libsodium_sys"
+
+[features]
+use-pkg-config = []

--- a/libsodium-sys/build.rs
+++ b/libsodium-sys/build.rs
@@ -51,7 +51,11 @@ fn main() {
     }
 
     let lib_dir_isset = env::var("SODIUM_LIB_DIR").is_ok();
-    let use_pkg_isset = env::var("SODIUM_USE_PKG_CONFIG").is_ok();
+    let use_pkg_isset = if cfg!(feature = "use-pkg-config") {
+        true
+    } else {
+        env::var("SODIUM_USE_PKG_CONFIG").is_ok()
+    };
     let shared_isset = env::var("SODIUM_SHARED").is_ok();
 
     if lib_dir_isset && use_pkg_isset {


### PR DESCRIPTION
This feature allows a crate to depend on sodiumoxide and force dynamic linking. This allows a project to revert to the old default without using a non-standard rust build system.