### PR TITLE
bump versions for release of v0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "sodiumoxide"
 readme = "README.md"
 repository = "https://github.com/sodiumoxide/sodiumoxide"
 categories = ["cryptography"]
-version = "0.2.0"
+version = "0.2.1"
 exclude = [
     "**/.gitignore",
     ".travis.yml",

--- a/libsodium-sys/Cargo.toml
+++ b/libsodium-sys/Cargo.toml
@@ -9,7 +9,7 @@ links = "sodium"
 name = "libsodium-sys"
 repository = "https://github.com/sodiumoxide/sodiumoxide.git"
 categories = ["cryptography", "api-bindings"]
-version = "0.2.0"
+version = "0.2.1"
 
 [badges]
 travis-ci = { repository = "sodiumoxide/sodiumoxide" }


### PR DESCRIPTION
Bumps the versions of libsodium-sys, and sodiumoxide to 0.2.1 to release the fixes for Failing to compile on mac as well as other issues.

I'm not aware of any breaking changes since 0.2.0, so I've marked it as 0.2.1 for now, happy to do anything else required if changes are needed.