### PR TITLE
Unpin libc dependency

### DIFF
--- a/libsodium-sys/Cargo.toml
+++ b/libsodium-sys/Cargo.toml
@@ -22,7 +22,7 @@ pkg-config = "0.3"
 
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]
-libc = { version = "=0.2.48" , default-features = false }
+libc = { version = "0.2" , default-features = false }
 vcpkg = "0.2"
 zip = "0.5"
 
@@ -32,7 +32,7 @@ libflate = "0.1"
 tar = "0.4"
 
 [dependencies]
-libc = { version = "=0.2.48" , default-features = false }
+libc = { version = "0.2" , default-features = false }
 
 [lib]
 name = "libsodium_sys"


### PR DESCRIPTION
This makes sure we don't run into unresolvable dependency conflicts if any crate depends on `libc = "> 0.2.48"`.