### PR TITLE
Add `AsRef<[u8]>` for newtypes

### DIFF
--- a/src/crypto/auth/auth_state_macros.rs
+++ b/src/crypto/auth/auth_state_macros.rs
@@ -84,7 +84,7 @@ mod test_s {
             let k = gen_key();
             let m = randombytes(i);
             let tag = authenticate(&m, &k);
-            let mut state = State::init(&k[..]);
+            let mut state = State::init(k.as_ref());
             state.update(&m);
             let tag2 = state.finalize();
             assert_eq!(tag, tag2);
@@ -98,7 +98,7 @@ mod test_s {
             let k = gen_key();
             let m = randombytes(i);
             let tag = authenticate(&m, &k);
-            let mut state = State::init(&k[..]);
+            let mut state = State::init(k.as_ref());
             for c in m.chunks(1) {
                 state.update(c);
             }

--- a/src/crypto/pwhash/mod.rs
+++ b/src/crypto/pwhash/mod.rs
@@ -47,7 +47,7 @@
 //! let pwh = pwhash::pwhash(passwd,
 //!                          pwhash::OPSLIMIT_INTERACTIVE,
 //!                          pwhash::MEMLIMIT_INTERACTIVE).unwrap();
-//! let pwh_bytes = &pwh[..];
+//! let pwh_bytes = pwh.as_ref();
 //! //store pwh_bytes somewhere
 //! ```
 //!

--- a/src/crypto/sign/ed25519.rs
+++ b/src/crypto/sign/ed25519.rs
@@ -338,7 +338,7 @@ mod test {
             let m = x2.from_hex().unwrap();
             let sm = sign(&m, &sk);
             verify(&sm, &pk).unwrap();
-            assert!(x1 == pk[..].to_hex());
+            assert!(x1 == pk.as_ref().to_hex());
             assert!(x3 == sm.to_hex());
         }
     }
@@ -369,8 +369,8 @@ mod test {
             let m = x2.from_hex().unwrap();
             let sig = sign_detached(&m, &sk);
             assert!(verify_detached(&sig, &m, &pk));
-            assert!(x1 == pk[..].to_hex());
-            let sm = sig[..].to_hex() + x2; // x2 is m hex encoded
+            assert!(x1 == pk.as_ref().to_hex());
+            let sm = sig.as_ref().to_hex() + x2; // x2 is m hex encoded
             assert!(x3 == sm);
         }
     }
@@ -448,7 +448,7 @@ mod test {
 
             assert!(validator_state.verify(&sig, &pk));
 
-            assert_eq!(x1, pk[..].to_hex());
+            assert_eq!(x1, pk.as_ref().to_hex());
         }
     }
 

--- a/src/newtype_macros.rs
+++ b/src/newtype_macros.rs
@@ -82,13 +82,6 @@ macro_rules! newtype_traits (($newtype:ident, $len:expr) => (
         }
     }
 
-    impl AsMut<[u8]> for $newtype {
-        #[inline]
-        fn as_mut(&mut self) -> &mut [u8] {
-            &mut self.0
-        }
-    }
-
     /// Allows a user to access the byte contents of an object as a slice.
     ///
     /// WARNING: it might be tempting to do comparisons on objects

--- a/src/newtype_macros.rs
+++ b/src/newtype_macros.rs
@@ -39,7 +39,7 @@ macro_rules! newtype_traits (($newtype:ident, $len:expr) => (
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where S: ::serde::Serializer
         {
-            serializer.serialize_bytes(&self[..])
+            serializer.serialize_bytes(&self.as_ref())
         }
     }
 
@@ -75,12 +75,27 @@ macro_rules! newtype_traits (($newtype:ident, $len:expr) => (
         }
     }
 
+    impl AsRef<[u8]> for $newtype {
+        #[inline]
+        fn as_ref(&self) -> &[u8] {
+            &self.0
+        }
+    }
+
+    impl AsMut<[u8]> for $newtype {
+        #[inline]
+        fn as_mut(&mut self) -> &mut [u8] {
+            &mut self.0
+        }
+    }
+
     /// Allows a user to access the byte contents of an object as a slice.
     ///
     /// WARNING: it might be tempting to do comparisons on objects
     /// by using `x[a..b] == y[a..b]`. This will open up for timing attacks
     /// when comparing for example authenticator tags. Because of this only
     /// use the comparison functions exposed by the sodiumoxide API.
+    #[deprecated(since="0.2.2", note="Use the `AsRef` or `AsMut` implementation instead")]
     impl ::std::ops::Index<::std::ops::Range<usize>> for $newtype {
         type Output = [u8];
         fn index(&self, _index: ::std::ops::Range<usize>) -> &[u8] {
@@ -93,6 +108,7 @@ macro_rules! newtype_traits (($newtype:ident, $len:expr) => (
     /// by using `x[..b] == y[..b]`. This will open up for timing attacks
     /// when comparing for example authenticator tags. Because of this only
     /// use the comparison functions exposed by the sodiumoxide API.
+    #[deprecated(since="0.2.2", note="Use the `AsRef` or `AsMut` implementation instead")]
     impl ::std::ops::Index<::std::ops::RangeTo<usize>> for $newtype {
         type Output = [u8];
         fn index(&self, _index: ::std::ops::RangeTo<usize>) -> &[u8] {
@@ -105,6 +121,7 @@ macro_rules! newtype_traits (($newtype:ident, $len:expr) => (
     /// by using `x[a..] == y[a..]`. This will open up for timing attacks
     /// when comparing for example authenticator tags. Because of this only
     /// use the comparison functions exposed by the sodiumoxide API.
+    #[deprecated(since="0.2.2", note="Use the `AsRef` or `AsMut` implementation instead")]
     impl ::std::ops::Index<::std::ops::RangeFrom<usize>> for $newtype {
         type Output = [u8];
         fn index(&self, _index: ::std::ops::RangeFrom<usize>) -> &[u8] {
@@ -117,6 +134,7 @@ macro_rules! newtype_traits (($newtype:ident, $len:expr) => (
     /// by using `x[] == y[]`. This will open up for timing attacks
     /// when comparing for example authenticator tags. Because of this only
     /// use the comparison functions exposed by the sodiumoxide API.
+    #[deprecated(since="0.2.2", note="Use the `AsRef` or `AsMut` implementation instead")]
     impl ::std::ops::Index<::std::ops::RangeFull> for $newtype {
         type Output = [u8];
         fn index(&self, _index: ::std::ops::RangeFull) -> &[u8] {
@@ -126,12 +144,6 @@ macro_rules! newtype_traits (($newtype:ident, $len:expr) => (
     ));
 
 macro_rules! public_newtype_traits (($newtype:ident) => (
-    impl AsRef<[u8]> for $newtype {
-        #[inline]
-        fn as_ref(&self) -> &[u8] {
-            &self[..]
-        }
-    }
     impl ::std::cmp::PartialOrd for $newtype {
         #[inline]
         fn partial_cmp(&self,
@@ -240,7 +252,7 @@ macro_rules! new_type {
         impl ::std::fmt::Debug for $name {
             fn fmt(&self,
                    formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                write!(formatter, "{}({:?})", stringify!($name), &self[..])
+                write!(formatter, "{}({:?})", stringify!($name), self.as_ref())
             }
         }
         );
@@ -286,7 +298,7 @@ macro_rules! new_type {
         impl ::std::fmt::Debug for $name {
             fn fmt(&self,
                    formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                write!(formatter, "{}({:?})", stringify!($name), &self[..])
+                write!(formatter, "{}({:?})", stringify!($name), self.as_ref())
             }
         }
         );


### PR DESCRIPTION
This seems like a much cleaner way to access the raw byte contents of newtypes instead
of exposing `Index` implementations.

We also deprecate the `Index` implementations (even though deprecation on trait-impls doesn't do anything for now). We should probably remove these implementations in the next major release.

Closes #321.