### PR TITLE
Implement memory locking and unlocking

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -25,6 +25,40 @@ pub fn memcmp(x: &[u8], y: &[u8]) -> bool {
     unsafe { ffi::sodium_memcmp(x.as_ptr() as *const _, y.as_ptr() as *const _, x.len()) == 0 }
 }
 
+
+/// `mlock()` locks memory given region which can help avoiding swapping the
+/// sensitive memory region to disk.
+///
+/// Operating system might limit the amount of memory a process can `mlock()`.
+/// This function can fail if `mlock()` fails to lock the memory.
+pub fn mlock(x: &mut [u8]) -> Result<(), ()> {
+    let ret = unsafe {
+        ffi::sodium_mlock(x.as_mut_ptr() as *mut _, x.len())
+    };
+    if ret == 0 {
+        Ok(())
+    } else {
+        Err(())
+    }
+}
+
+/// `munlock()` unlocks memory region.
+///
+/// `munlock()` overwrites the region with zeros before unlocking it, so it
+/// doesn't have to be done before calling this function.
+pub fn munlock(x: &mut [u8]) -> Result<(), ()> {
+    let ret = unsafe {
+        // sodium_munlock() internally calls sodium_memzero() to clear memory
+        // region
+        ffi::sodium_munlock(x.as_mut_ptr() as *mut _, x.len())
+    };
+    if ret == 0 {
+        Ok(())
+    } else {
+        Err(())
+    }
+}
+
 /// `increment_le()` treats `x` as an unsigned little-endian number and increments it in
 /// constant time.
 ///
@@ -201,5 +235,16 @@ mod test {
             assert!(add_le(&mut x, &z).is_err());
             assert_eq!(x, vec![1u8; i]);
         }
+    }
+
+    #[test]
+    fn test_mlock_munlock() {
+        let t = b"hello world";
+        let mut x = Vec::new();
+        x.extend_from_slice(t);
+        assert!(mlock(&mut x).is_ok());
+        assert_eq!(&x, t);
+        assert!(munlock(&mut x).is_ok());
+        assert_ne!(&x, t);
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -254,7 +254,10 @@ mod test {
         // duration.
         const LOCK_LIMIT: libc::rlim_t = 16384;
 
-        let mut limit = libc::rlimit { rlim_cur: 0, rlim_max: 0 };
+        let mut limit = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
         let ret = unsafe { libc::getrlimit(libc::RLIMIT_MEMLOCK, &mut limit) };
         assert_eq!(ret, 0, "libc::getrlimit failed");
 
@@ -265,7 +268,7 @@ mod test {
         let ret = unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &limit) };
         assert_eq!(ret, 0, "libc::setrlimit failed");
 
-        let mut x = vec![0; 5*LOCK_LIMIT as usize];
+        let mut x = vec![0; 5 * LOCK_LIMIT as usize];
         assert!(mlock(&mut x).is_err());
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -25,16 +25,13 @@ pub fn memcmp(x: &[u8], y: &[u8]) -> bool {
     unsafe { ffi::sodium_memcmp(x.as_ptr() as *const _, y.as_ptr() as *const _, x.len()) == 0 }
 }
 
-
 /// `mlock()` locks memory given region which can help avoiding swapping the
 /// sensitive memory region to disk.
 ///
 /// Operating system might limit the amount of memory a process can `mlock()`.
 /// This function can fail if `mlock()` fails to lock the memory.
 pub fn mlock(x: &mut [u8]) -> Result<(), ()> {
-    let ret = unsafe {
-        ffi::sodium_mlock(x.as_mut_ptr() as *mut _, x.len())
-    };
+    let ret = unsafe { ffi::sodium_mlock(x.as_mut_ptr() as *mut _, x.len()) };
     if ret == 0 {
         Ok(())
     } else {
@@ -49,7 +46,7 @@ pub fn mlock(x: &mut [u8]) -> Result<(), ()> {
 pub fn munlock(x: &mut [u8]) -> Result<(), ()> {
     let ret = unsafe {
         // sodium_munlock() internally calls sodium_memzero() to clear memory
-        // region
+        // region.
         ffi::sodium_munlock(x.as_mut_ptr() as *mut _, x.len())
     };
     if ret == 0 {


### PR DESCRIPTION
This PR implements two utils: `mlock()` and `munlock()` which are direct wrappers for `sodium_mlock()` and `sodium_munlock()`.

The unit test is pretty silly, but I'm not sure what we could test for `mlock`.

libsodium recommends using these functions for password (https://libsodium.gitbook.io/doc/advanced/scrypt#notes):

> It is highly recommended to use sodium_mlock() to lock memory regions storing cleartext passwords, and to call sodium_munlock() right after crypto_pwhash_scryptsalsa208sha256_str() and crypto_pwhash_scryptsalsa208sha256_str_verify() return.
>
> sodium_munlock() overwrites the region with zeros before unlocking it, so it doesn't have to be done before calling this function.

My use case is to use these functions for implementing `struct Password(Vec<u8>)` with appropriate locking and `Drop` trait implementation doing zeroing and unlocking of `Password`.