### PR TITLE
Initialize libsodium with global constructor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ coveralls = { repository = "sodiumoxide/sodiumoxide" }
 libc = { version = "^0.2.41" , default-features = false }
 libsodium-sys = { version = "0.2.1", path = "libsodium-sys" }
 serde = { version = "^1.0.59", default-features = false, optional = true }
+ctor = "0.1.7"
 
 [dev-dependencies]
 serde = "^1.0.59"

--- a/src/crypto/aead/aead_macros.rs
+++ b/src/crypto/aead/aead_macros.rs
@@ -40,10 +40,6 @@ new_type! {
 }
 
 /// `gen_key()` randomly generates a secret key
-///
-/// THREAD SAFETY: `gen_key()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
 pub fn gen_key() -> Key {
     let mut k = Key([0u8; KEYBYTES]);
     randombytes_into(&mut k.0);
@@ -51,10 +47,6 @@ pub fn gen_key() -> Key {
 }
 
 /// `gen_nonce()` randomly generates a nonce
-///
-/// THREAD SAFETY: `gen_key()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
 pub fn gen_nonce() -> Nonce {
     let mut n = Nonce([0u8; NONCEBYTES]);
     randombytes_into(&mut n.0);

--- a/src/crypto/auth/auth_macros.rs
+++ b/src/crypto/auth/auth_macros.rs
@@ -29,10 +29,6 @@ new_type! {
 }
 
 /// `gen_key()` randomly generates a key for authentication
-///
-/// THREAD SAFETY: `gen_key()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
 pub fn gen_key() -> Key {
     let mut k = [0; KEYBYTES];
     randombytes_into(&mut k);

--- a/src/crypto/box_/curve25519xsalsa20poly1305.rs
+++ b/src/crypto/box_/curve25519xsalsa20poly1305.rs
@@ -81,10 +81,6 @@ new_type! {
 }
 
 /// `gen_keypair()` randomly generates a secret key and a corresponding public key.
-///
-/// THREAD SAFETY: `gen_keypair()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
 pub fn gen_keypair() -> (PublicKey, SecretKey) {
     unsafe {
         let mut pk = PublicKey([0u8; PUBLICKEYBYTES]);
@@ -95,10 +91,6 @@ pub fn gen_keypair() -> (PublicKey, SecretKey) {
 }
 
 /// `key_pair_from_seed()` deterministically derives a key pair from a single key seed (crypto_box_SEEDBYTES bytes).
-///
-/// THREAD SAFETY: `key_pair_from_seed()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
 pub fn keypair_from_seed(seed: &Seed) -> (PublicKey, SecretKey) {
     unsafe {
         let mut pk = PublicKey([0u8; PUBLICKEYBYTES]);
@@ -113,10 +105,6 @@ pub fn keypair_from_seed(seed: &Seed) -> (PublicKey, SecretKey) {
 }
 
 /// `gen_nonce()` randomly generates a nonce
-///
-/// THREAD SAFETY: `gen_nonce()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
 pub fn gen_nonce() -> Nonce {
     let mut n = [0; NONCEBYTES];
     randombytes_into(&mut n);

--- a/src/crypto/kx/x25519blake2b.rs
+++ b/src/crypto/kx/x25519blake2b.rs
@@ -44,10 +44,6 @@ new_type! {
 
 /// `gen_keypair()` randomly generates a secret key and a corresponding public
 /// key.
-///
-/// THREAD SAFETY: `gen_keypair()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
 pub fn gen_keypair() -> (PublicKey, SecretKey) {
     unsafe {
         let mut pk = PublicKey([0u8; PUBLICKEYBYTES]);

--- a/src/crypto/pwhash/argon2_macros.rs
+++ b/src/crypto/pwhash/argon2_macros.rs
@@ -76,9 +76,6 @@ new_type! {
 }
 
 /// `gen_salt()` randomly generates a new `Salt` for key derivation
-///
-/// THREAD SAFETY: `gen_salt()` is thread-safe provided that you have called
-/// `sodiumoxide::init()` once before using any other function from sodiumoxide.
 pub fn gen_salt() -> Salt {
     let mut salt = Salt([0; SALTBYTES]);
     randombytes_into(&mut salt.0);

--- a/src/crypto/pwhash/scryptsalsa208sha256.rs
+++ b/src/crypto/pwhash/scryptsalsa208sha256.rs
@@ -61,9 +61,6 @@ new_type! {
 }
 
 /// `gen_salt()` randombly generates a new `Salt` for key derivation
-///
-/// THREAD SAFETY: `gen_salt()` is thread-safe provided that you have called
-/// `sodiumoxide::init()` once before using any other function from sodiumoxide.
 pub fn gen_salt() -> Salt {
     let mut salt = Salt([0; SALTBYTES]);
     randombytes_into(&mut salt.0);

--- a/src/crypto/secretbox/xsalsa20poly1305.rs
+++ b/src/crypto/secretbox/xsalsa20poly1305.rs
@@ -42,10 +42,6 @@ new_type! {
 pub const MACBYTES: usize = ffi::crypto_secretbox_xsalsa20poly1305_MACBYTES as usize;
 
 /// `gen_key()` randomly generates a secret key
-///
-/// THREAD SAFETY: `gen_key()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
 pub fn gen_key() -> Key {
     let mut key = [0; KEYBYTES];
     randombytes_into(&mut key);
@@ -53,10 +49,6 @@ pub fn gen_key() -> Key {
 }
 
 /// `gen_nonce()` randomly generates a nonce
-///
-/// THREAD SAFETY: `gen_key()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
 pub fn gen_nonce() -> Nonce {
     let mut nonce = [0; NONCEBYTES];
     randombytes_into(&mut nonce);

--- a/src/crypto/secretstream/secretstream_macros.rs
+++ b/src/crypto/secretstream/secretstream_macros.rs
@@ -113,10 +113,6 @@ new_type! {
 }
 
 /// `gen_key()` randomly generates a secret key
-///
-/// THREAD SAFETY: `gen_key()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
 pub fn gen_key() -> Key {
     let mut key = [0; KEYBYTES];
     randombytes_into(&mut key);

--- a/src/crypto/shorthash/siphash24.rs
+++ b/src/crypto/shorthash/siphash24.rs
@@ -23,10 +23,6 @@ new_type! {
 }
 
 /// `gen_key()` randomly generates a key for shorthash
-///
-/// THREAD SAFETY: `gen_key()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
 pub fn gen_key() -> Key {
     let mut k = [0; KEYBYTES];
     randombytes_into(&mut k);

--- a/src/crypto/sign/ed25519.rs
+++ b/src/crypto/sign/ed25519.rs
@@ -53,10 +53,6 @@ new_type! {
 
 /// `gen_keypair()` randomly generates a secret key and a corresponding public
 /// key.
-///
-/// THREAD SAFETY: `gen_keypair()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
 pub fn gen_keypair() -> (PublicKey, SecretKey) {
     let mut pk = PublicKey([0u8; PUBLICKEYBYTES]);
     let mut sk = SecretKey([0u8; SECRETKEYBYTES]);

--- a/src/crypto/stream/stream_macros.rs
+++ b/src/crypto/stream/stream_macros.rs
@@ -28,10 +28,6 @@ new_type! {
 }
 
 /// `gen_key()` randomly generates a key for symmetric encryption
-///
-/// THREAD SAFETY: `gen_key()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
 pub fn gen_key() -> Key {
     let mut key = [0; KEYBYTES];
     randombytes_into(&mut key);
@@ -39,10 +35,6 @@ pub fn gen_key() -> Key {
 }
 
 /// `gen_nonce()` randomly generates a nonce for symmetric encryption
-///
-/// THREAD SAFETY: `gen_nonce()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
 ///
 /// NOTE: When using primitives with short nonces (e.g. salsa20, salsa208, salsa2012)
 /// do not use random nonces since the probability of nonce-collision is not negligible

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,8 @@
 
 extern crate libsodium_sys as ffi;
 
+#[macro_use]
+extern crate ctor;
 extern crate libc;
 #[cfg(test)]
 extern crate rustc_serialize;
@@ -89,11 +91,22 @@ mod prelude {
 /// thread-safe
 ///
 /// `init()` returns `Ok` if initialization succeeded and `Err` if it failed.
+#[deprecated(
+    since = "0.2.2",
+    note = "libsodium is automatically initialized by sodiumoxide now."
+)]
 pub fn init() -> Result<(), ()> {
     if unsafe { ffi::sodium_init() } >= 0 {
         Ok(())
     } else {
         Err(())
+    }
+}
+
+#[ctor]
+fn init_real() {
+    unsafe {
+        ffi::sodium_init();
     }
 }
 

--- a/src/randombytes.rs
+++ b/src/randombytes.rs
@@ -5,10 +5,6 @@ use ffi;
 use prelude::*;
 
 /// `randombytes()` randomly generates size bytes of data.
-///
-/// THREAD SAFETY: `randombytes()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
 pub fn randombytes(size: usize) -> Vec<u8> {
     unsafe {
         let mut buf = vec![0u8; size];
@@ -18,10 +14,6 @@ pub fn randombytes(size: usize) -> Vec<u8> {
 }
 
 /// `randombytes_into()` fills a buffer `buf` with random data.
-///
-/// THREAD SAFETY: `randombytes_into()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
 pub fn randombytes_into(buf: &mut [u8]) {
     unsafe {
         ffi::randombytes_buf(buf.as_mut_ptr() as *mut _, buf.len());
@@ -33,10 +25,6 @@ pub fn randombytes_into(buf: &mut [u8]) {
 /// possible output values even when `upper_bound` is not a power of 2. Note
 /// that an `upper_bound` < 2 leaves only a  single element to be chosen, namely
 /// 0.
-///
-/// THREAD SAFETY: `randombytes()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
 pub fn randombytes_uniform(upper_bound: u32) -> u32 {
     unsafe { ffi::randombytes_uniform(upper_bound) }
 }
@@ -47,22 +35,16 @@ mod test {
 
     #[test]
     fn test_randombytes_uniform_0() {
-        ::init().unwrap();
-
         assert_eq!(randombytes_uniform(0), 0);
     }
 
     #[test]
     fn test_randombytes_uniform_1() {
-        ::init().unwrap();
-
         assert_eq!(randombytes_uniform(1), 0);
     }
 
     #[test]
     fn test_randombytes_uniform_7() {
-        ::init().unwrap();
-
         assert!(randombytes_uniform(7) < 7);
     }
 }


### PR DESCRIPTION
This frees the user of sodiumoxide from remembering to call `sodiumoxide::init()`, which we deprecate for now.

NOTE: maybe we shouldn't deprecate this function and instead keep it so that a caller can use it to make sure that initialization hasn't somehow failed? This should be discussed before merging this pull-request.

We could panic in the constructor instead, but that feels a bit scary since it runs pre-main, and we don't have any guarantees about the state of rust when that happend (I might be wrong here, please correct me if I am).