### PR TITLE
Verifying libsodium with minisign instead of sha2

### DIFF
--- a/libsodium-sys/Cargo.toml
+++ b/libsodium-sys/Cargo.toml
@@ -16,9 +16,8 @@ travis-ci = { repository = "sodiumoxide/sodiumoxide" }
 
 [build-dependencies]
 http_req = { version = "0.4", default-features = false, features = ["rust-tls"] }
-sha2 = "0.8"
 pkg-config = "0.3"
-
+minisign-verify = "0.1.1"
 
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]


### PR DESCRIPTION
This would resolve 326, and makes it so we don't have to keep updating hard-coded SHA hashes all the time. The build seems to run fine on Windows and Ubuntu.

Sorry if anything is out of order - I'm a bit new to Rust, not to mention contributing to open source projects in general.