### PR TITLE
Replace rustc-serialize with hex crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,9 @@ libsodium-sys = { version = "0.2.1", path = "libsodium-sys" }
 serde = { version = "^1.0.59", default-features = false, optional = true }
 
 [dev-dependencies]
+hex = "0.3"
 serde = "^1.0.59"
 serde_json = "^1.0.17"
-rustc-serialize = "^0.3.24"
 rmp-serde = "^0.13.7"
 
 [features]

--- a/src/crypto/generichash/mod.rs
+++ b/src/crypto/generichash/mod.rs
@@ -145,7 +145,6 @@ mod test {
 
     #[test]
     fn test_blake2b_vectors() {
-        use rustc_serialize::hex::FromHex;
         use std::fs::File;
         use std::io::{BufRead, BufReader};
 
@@ -166,21 +165,21 @@ mod test {
                 }
 
                 assert!(line.starts_with("in:"));
-                line[3..].trim().from_hex().unwrap()
+                hex::decode(line[3..].trim()).unwrap()
             };
 
             let key = {
                 line.clear();
                 r.read_line(&mut line).unwrap();
                 assert!(line.starts_with("key:"));
-                line[4..].trim().from_hex().unwrap()
+                hex::decode(line[4..].trim()).unwrap()
             };
 
             let expected_hash = {
                 line.clear();
                 r.read_line(&mut line).unwrap();
                 assert!(line.starts_with("hash:"));
-                line[5..].from_hex().unwrap()
+                hex::decode(&line[5..].trim()).unwrap()
             };
 
             let mut hasher = State::new(64, Some(&key)).unwrap();

--- a/src/crypto/hash/sha256.rs
+++ b/src/crypto/hash/sha256.rs
@@ -59,7 +59,6 @@ mod test {
     }
 
     fn test_nist_vector(filename: &str) {
-        use rustc_serialize::hex::FromHex;
         use std::fs::File;
         use std::io::{BufRead, BufReader};
 
@@ -76,11 +75,11 @@ mod test {
                 let len: usize = line[6..].trim().parse().unwrap();
                 line.clear();
                 r.read_line(&mut line).unwrap();
-                let rawmsg = line[6..].from_hex().unwrap();
+                let rawmsg = hex::decode(&line[6..].trim()).unwrap();
                 let msg = &rawmsg[..len / 8];
                 line.clear();
                 r.read_line(&mut line).unwrap();
-                let md = line[5..].from_hex().unwrap();
+                let md = hex::decode(&line[5..].trim()).unwrap();
                 let Digest(digest) = hash(msg);
                 assert!(&digest[..] == &md[..]);
             }

--- a/src/crypto/hash/sha512.rs
+++ b/src/crypto/hash/sha512.rs
@@ -44,7 +44,6 @@ mod test {
     }
 
     fn test_nist_vector(filename: &str) {
-        use rustc_serialize::hex::FromHex;
         use std::fs::File;
         use std::io::{BufRead, BufReader};
 
@@ -61,11 +60,11 @@ mod test {
                 let len: usize = line[6..].trim().parse().unwrap();
                 line.clear();
                 r.read_line(&mut line).unwrap();
-                let rawmsg = line[6..].from_hex().unwrap();
+                let rawmsg = hex::decode(&line[6..].trim()).unwrap();
                 let msg = &rawmsg[..len / 8];
                 line.clear();
                 r.read_line(&mut line).unwrap();
-                let md = line[5..].from_hex().unwrap();
+                let md = hex::decode(&line[5..].trim()).unwrap();
                 let Digest(digest) = hash(msg);
                 assert!(&digest[..] == &md[..]);
             }

--- a/src/crypto/sign/ed25519.rs
+++ b/src/crypto/sign/ed25519.rs
@@ -316,7 +316,6 @@ mod test {
     fn test_vectors() {
         // test vectors from the Python implementation
         // from the [Ed25519 Homepage](http://ed25519.cr.yp.to/software.html)
-        use rustc_serialize::hex::{FromHex, ToHex};
         use std::fs::File;
         use std::io::{BufRead, BufReader};
 
@@ -328,18 +327,18 @@ mod test {
             let x1 = x.next().unwrap();
             let x2 = x.next().unwrap();
             let x3 = x.next().unwrap();
-            let seed_bytes = x0[..64].from_hex().unwrap();
+            let seed_bytes = hex::decode(&x0[..64]).unwrap();
             assert!(seed_bytes.len() == SEEDBYTES);
             let mut seed = Seed([0u8; SEEDBYTES]);
             for (s, b) in seed.0.iter_mut().zip(seed_bytes.iter()) {
                 *s = *b
             }
             let (pk, sk) = keypair_from_seed(&seed);
-            let m = x2.from_hex().unwrap();
+            let m = hex::decode(x2).unwrap();
             let sm = sign(&m, &sk);
             verify(&sm, &pk).unwrap();
-            assert!(x1 == pk.as_ref().to_hex());
-            assert!(x3 == sm.to_hex());
+            assert!(x1 == hex::encode(pk));
+            assert!(x3 == hex::encode(sm));
         }
     }
 
@@ -347,7 +346,6 @@ mod test {
     fn test_vectors_detached() {
         // test vectors from the Python implementation
         // from the [Ed25519 Homepage](http://ed25519.cr.yp.to/software.html)
-        use rustc_serialize::hex::{FromHex, ToHex};
         use std::fs::File;
         use std::io::{BufRead, BufReader};
 
@@ -359,18 +357,18 @@ mod test {
             let x1 = x.next().unwrap();
             let x2 = x.next().unwrap();
             let x3 = x.next().unwrap();
-            let seed_bytes = x0[..64].from_hex().unwrap();
+            let seed_bytes = hex::decode(&x0[..64]).unwrap();
             assert!(seed_bytes.len() == SEEDBYTES);
             let mut seed = Seed([0u8; SEEDBYTES]);
             for (s, b) in seed.0.iter_mut().zip(seed_bytes.iter()) {
                 *s = *b
             }
             let (pk, sk) = keypair_from_seed(&seed);
-            let m = x2.from_hex().unwrap();
+            let m = hex::decode(x2).unwrap();
             let sig = sign_detached(&m, &sk);
             assert!(verify_detached(&sig, &m, &pk));
-            assert!(x1 == pk.as_ref().to_hex());
-            let sm = sig.as_ref().to_hex() + x2; // x2 is m hex encoded
+            assert!(x1 == hex::encode(pk));
+            let sm = hex::encode(sig) + x2; // x2 is m hex encoded
             assert!(x3 == sm);
         }
     }
@@ -418,7 +416,6 @@ mod test {
     fn test_streaming_vectors() {
         // test vectors from the Python implementation
         // from the [Ed25519 Homepage](http://ed25519.cr.yp.to/software.html)
-        use rustc_serialize::hex::{FromHex, ToHex};
         use std::fs::File;
         use std::io::{BufRead, BufReader};
 
@@ -429,7 +426,7 @@ mod test {
             let x0 = x.next().unwrap();
             let x1 = x.next().unwrap();
             let x2 = x.next().unwrap();
-            let seed_bytes = x0[..64].from_hex().unwrap();
+            let seed_bytes = hex::decode(&x0[..64]).unwrap();
             assert!(seed_bytes.len() == SEEDBYTES);
             let mut seed = Seed([0u8; SEEDBYTES]);
             for (s, b) in seed.0.iter_mut().zip(seed_bytes.iter()) {
@@ -437,7 +434,7 @@ mod test {
             }
             let (pk, sk) = keypair_from_seed(&seed);
 
-            let m = x2.from_hex().unwrap();
+            let m = hex::decode(x2).unwrap();
 
             let mut creation_state = State::init();
             creation_state.update(&m);
@@ -448,7 +445,7 @@ mod test {
 
             assert!(validator_state.verify(&sig, &pk));
 
-            assert_eq!(x1, pk.as_ref().to_hex());
+            assert_eq!(x1, hex::encode(pk));
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,9 +61,9 @@
 
 extern crate libsodium_sys as ffi;
 
-extern crate libc;
 #[cfg(test)]
-extern crate rustc_serialize;
+extern crate hex;
+extern crate libc;
 #[cfg(any(test, feature = "serde"))]
 extern crate serde;
 #[cfg(not(feature = "std"))]


### PR DESCRIPTION
`rustc-serialize` is deprecated and it was only used for hex decoding/encoding in tests. Replace it with `hex` crate which specialized to scratch this specific itch.