### PR TITLE
Add include & lib build metadata to libsodium-sys

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,14 +5,17 @@ environment:
     # stable x86_64 with static libsodium from sources
   - TARGET: x86_64-pc-windows-msvc
     RUST_CHANNEL: stable
+    RUST_BACKTRACE: 1
 
     # stable x86 with static libsodium from sources
   - TARGET: i686-pc-windows-msvc
     RUST_CHANNEL: stable
+    RUST_BACKTRACE: 1
 
   # stable x86_64 with static libsodium from sources
   - TARGET: x86_64-pc-windows-gnu
     RUST_CHANNEL: stable
+    RUST_BACKTRACE: 1
 
     # stable x86_64 with dynamic libsodium from vcpkg
   - TARGET: x86_64-pc-windows-msvc
@@ -20,6 +23,7 @@ environment:
     VCPKG_TARGET: x64-windows
     SODIUM_USE_PKG_CONFIG: 1
     VCPKGRS_DYNAMIC: 1
+    RUST_BACKTRACE: 1
 
 install:
   - ps: |
@@ -39,10 +43,8 @@ cache:
   - C:\Users\appveyor\.cargo\registry
   - target
 
-build_script:
-  - cmd: cargo build --target %TARGET%
-  - cmd: cargo build --release --target %TARGET%
+build: false
 
 test_script:
-  - cmd: cargo test --target %TARGET%
-  - cmd: cargo test --release --target %TARGET%
+  - cargo test --target %TARGET%
+  - cargo test --release --target %TARGET%

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
 
 script:
   - cargo build --verbose
-  - cargo test --verbose
+  - cargo test --verbose --all
   - cargo test --verbose --no-default-features --features std
   - cargo doc
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 ]
 
 [workspace]
-members = ["libsodium-sys"]
+members = ["libsodium-sys", "testcrate"]
 
 [badges]
 travis-ci = { repository = "sodiumoxide/sodiumoxide" }

--- a/libsodium-sys/.gitignore
+++ b/libsodium-sys/.gitignore
@@ -1,0 +1,30 @@
+#### IDEs ####
+### CLion ###
+# CMake
+cmake-build-debug/
+
+### IntelliJ ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### Vim ###
+.sw[a-p]
+.*.sw[a-p]
+Session.vim
+.netrwhist
+*~
+
+### Visual Studio Code ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+.history
+
+#### Languages ####
+### Rust ###
+/target/
+Cargo.lock

--- a/libsodium-sys/Cargo.toml
+++ b/libsodium-sys/Cargo.toml
@@ -16,6 +16,8 @@ travis-ci = { repository = "sodiumoxide/sodiumoxide" }
 
 [build-dependencies]
 pkg-config = "0.3"
+tar = "0.4"
+libflate = "0.1"
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]
 libc = { version = "0.2" , default-features = false }
@@ -23,8 +25,6 @@ vcpkg = "0.2"
 
 [target.'cfg(not(target_env = "msvc"))'.build-dependencies]
 cc = "1.0"
-libflate = "0.1"
-tar = "0.4"
 
 [dependencies]
 libc = { version = "0.2" , default-features = false }

--- a/libsodium-sys/README.md
+++ b/libsodium-sys/README.md
@@ -1,0 +1,12 @@
+> libsodium-sys
+
+# Build output ENV Variables
+This is the possible build metadata for the crate.
+* `DEP_SODIUM_INCLUDE` is the directory which contains the `sodium.h` header.
+    It is only available if the header was installed and `SODIUM_LIB_DIR` was not set.
+* `DEP_SODIUM_LIB` is the directory containing the compiled library.
+    It is only available if `SODIUM_LIB_DIR` was not set.
+
+See [`link build metadata`] for more information about build metadata.
+
+[`link build metadata`]: https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key

--- a/libsodium-sys/build.rs
+++ b/libsodium-sys/build.rs
@@ -6,15 +6,14 @@ extern crate libc;
 #[cfg(target_env = "msvc")]
 extern crate vcpkg;
 
-#[cfg(not(target_env = "msvc"))]
 extern crate libflate;
-
-#[cfg(not(target_env = "msvc"))]
+extern crate pkg_config;
 extern crate tar;
 
-extern crate pkg_config;
-
-use std::env;
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
 
 static VERSION: &'static str = "1.0.18";
 
@@ -97,12 +96,18 @@ This function will set `cargo` flags.
 #[cfg(target_env = "msvc")]
 fn find_libsodium_pkg() {
     match vcpkg::probe_package("libsodium") {
-        Ok(_) => {
+        Ok(lib) => {
             println!(
                 "cargo:warning=Using unknown libsodium version.  This crate is tested against \
                  {} and may not be fully compatible with other versions.",
                 VERSION
             );
+            for lib_dir in &lib.link_paths {
+                println!("cargo:lib={}", lib_dir.to_str().unwrap());
+            }
+            for include_dir in &lib.include_paths {
+                println!("cargo:include={}", include_dir.to_str().unwrap());
+            }
         }
         Err(e) => {
             panic!(format!("Error: {:?}", e));
@@ -124,6 +129,12 @@ fn find_libsodium_pkg() {
                     lib.version, VERSION, lib.version
                 );
             }
+            for lib_dir in &lib.link_paths {
+                println!("cargo:lib={}", lib_dir.to_str().unwrap());
+            }
+            for include_dir in &lib.include_paths {
+                println!("cargo:include={}", include_dir.to_str().unwrap());
+            }
         }
         Err(e) => {
             panic!(format!("Error: {:?}", e));
@@ -131,130 +142,16 @@ fn find_libsodium_pkg() {
     }
 }
 
-#[cfg(any(windows, target_env = "msvc"))]
-fn get_crate_dir() -> String {
-    env::var("CARGO_MANIFEST_DIR").unwrap()
-}
-
-#[cfg(target_env = "msvc")]
-fn is_release_profile() -> bool {
-    env::var("PROFILE").unwrap() == "release"
-}
-
-#[cfg(all(target_env = "msvc", target_pointer_width = "32"))]
-fn build_libsodium() {
-    println!("cargo:rustc-link-lib=static=libsodium");
-    if is_release_profile() {
-        println!(
-            "cargo:rustc-link-search=native={}/msvc/Win32/Release/v140/",
-            get_crate_dir()
-        );
-    } else {
-        println!(
-            "cargo:rustc-link-search=native={}/msvc/Win32/Debug/v140/",
-            get_crate_dir()
-        );
-    }
-}
-
-#[cfg(all(target_env = "msvc", target_pointer_width = "64"))]
-fn build_libsodium() {
-    println!("cargo:rustc-link-lib=static=libsodium");
-    if is_release_profile() {
-        println!(
-            "cargo:rustc-link-search=native={}/msvc/x64/Release/v140/",
-            get_crate_dir()
-        );
-    } else {
-        println!(
-            "cargo:rustc-link-search=native={}/msvc/x64/Debug/v140/",
-            get_crate_dir()
-        );
-    }
-}
-
-#[cfg(all(windows, not(target_env = "msvc"), target_pointer_width = "32"))]
-fn build_libsodium() {
-    println!("cargo:rustc-link-lib=static=sodium");
-    println!(
-        "cargo:rustc-link-search=native={}/mingw/win32/",
-        get_crate_dir()
-    );
-}
-
-#[cfg(all(windows, not(target_env = "msvc"), target_pointer_width = "64"))]
-fn build_libsodium() {
-    println!("cargo:rustc-link-lib=static=sodium");
-    println!(
-        "cargo:rustc-link-search=native={}/mingw/win64/",
-        get_crate_dir()
-    );
+#[cfg(windows)]
+fn make_libsodium(_: &str, _: &Path, _: &Path) -> PathBuf {
+    // We don't build anything on windows, we simply linked to precompiled
+    // libs.
+    get_lib_dir()
 }
 
 #[cfg(not(windows))]
-fn get_archive(filename: &str) -> std::io::Cursor<Vec<u8>> {
-    use std::fs::File;
-    use std::io::{BufReader, Read};
-
-    let f = File::open(filename).expect(&format!("Failed to open {}", filename));
-    let mut reader = BufReader::new(f);
-    let mut content = Vec::new();
-    reader
-        .read_to_end(&mut content)
-        .expect(&format!("Failed to read {}", filename));
-
-    std::io::Cursor::new(content)
-}
-
-#[cfg(not(windows))]
-fn get_install_dir() -> String {
-    env::var("OUT_DIR").unwrap() + "/installed"
-}
-
-#[cfg(not(windows))]
-fn build_libsodium() {
-    use libflate::gzip::Decoder;
-    use std::process::Command;
-    use std::{fs, path::Path, str};
-    use tar::Archive;
-
-    // Determine build target triple
-    let target = env::var("TARGET").unwrap();
-
-    // Determine filenames
-    let basename = format!("libsodium-{}", VERSION);
-    let filename = format!("{}.tar.gz", basename);
-
-    // Determine source and install dir
-    let mut install_dir = get_install_dir();
-    let mut source_dir = env::var("OUT_DIR").unwrap() + "/source";
-
-    // Avoid issues with paths containing spaces by falling back to using a tempfile.
-    // See https://github.com/jedisct1/libsodium/issues/207
-    if install_dir.contains(" ") {
-        let fallback_path = "/tmp/".to_string() + &basename + "/" + &target;
-        install_dir = fallback_path.clone() + "/installed";
-        source_dir = fallback_path.clone() + "/source";
-        println!(
-            "cargo:warning=The path to the usual build directory contains spaces and hence \
-             can't be used to build libsodium.  Falling back to use {}.  If running `cargo \
-             clean`, ensure you also delete this fallback directory",
-            fallback_path
-        );
-    }
-
-    // Create directories
-    fs::create_dir_all(&install_dir).unwrap();
-    fs::create_dir_all(&source_dir).unwrap();
-
-    // Get sources
-    let compressed_file = get_archive(&filename);
-
-    // Unpack the tarball
-    let gz_decoder = Decoder::new(compressed_file).unwrap();
-    let mut archive = Archive::new(gz_decoder);
-    archive.unpack(&source_dir).unwrap();
-    source_dir.push_str(&format!("/{}", basename));
+fn make_libsodium(target: &str, source_dir: &Path, install_dir: &Path) -> PathBuf {
+    use std::{process::Command, str};
 
     // Decide on CC, CFLAGS and the --host configure argument
     let build = cc::Build::new();
@@ -349,7 +246,7 @@ fn build_libsodium() {
     }
 
     // Run `./configure`
-    let prefix_arg = format!("--prefix={}", install_dir);
+    let prefix_arg = format!("--prefix={}", install_dir.to_str().unwrap());
     let mut configure_cmd = Command::new("./configure");
     if !compiler.is_empty() {
         configure_cmd.env("CC", &compiler);
@@ -425,6 +322,123 @@ fn build_libsodium() {
         );
     }
 
-    println!("cargo:rustc-link-lib=static=sodium");
-    println!("cargo:rustc-link-search=native={}/lib", install_dir);
+    install_dir.join("lib")
+}
+
+#[cfg(any(windows, target_env = "msvc"))]
+fn get_crate_dir() -> PathBuf {
+    env::var("CARGO_MANIFEST_DIR").unwrap().into()
+}
+
+#[cfg(target_env = "msvc")]
+fn is_release_profile() -> bool {
+    env::var("PROFILE").unwrap() == "release"
+}
+
+#[cfg(all(target_env = "msvc", target_pointer_width = "32"))]
+fn get_lib_dir() -> PathBuf {
+    if is_release_profile() {
+        get_crate_dir().join("msvc/Win32/Release/v140/")
+    } else {
+        get_crate_dir().join("msvc/Win32/Debug/v140/")
+    }
+}
+
+#[cfg(all(target_env = "msvc", target_pointer_width = "64"))]
+fn get_lib_dir() -> PathBuf {
+    if is_release_profile() {
+        get_crate_dir().join("msvc/x64/Release/v140/")
+    } else {
+        get_crate_dir().join("msvc/x64/Debug/v140/")
+    }
+}
+
+#[cfg(all(windows, not(target_env = "msvc"), target_pointer_width = "32"))]
+fn get_lib_dir() -> PathBuf {
+    get_crate_dir().join("mingw/win32/")
+}
+
+#[cfg(all(windows, not(target_env = "msvc"), target_pointer_width = "64"))]
+fn get_lib_dir() -> PathBuf {
+    get_crate_dir().join("mingw/win64/")
+}
+
+fn get_archive(filename: &str) -> std::io::Cursor<Vec<u8>> {
+    use std::fs::File;
+    use std::io::{BufReader, Read};
+
+    let f = File::open(filename).expect(&format!("Failed to open {}", filename));
+    let mut reader = BufReader::new(f);
+    let mut content = Vec::new();
+    reader
+        .read_to_end(&mut content)
+        .expect(&format!("Failed to read {}", filename));
+
+    std::io::Cursor::new(content)
+}
+
+fn get_install_dir() -> PathBuf {
+    PathBuf::from(env::var("OUT_DIR").unwrap()).join("installed")
+}
+
+fn build_libsodium() {
+    use libflate::gzip::Decoder;
+    use std::fs;
+    use tar::Archive;
+
+    // Determine build target triple
+    let target = env::var("TARGET").unwrap();
+
+    // Determine filenames
+    let basename = format!("libsodium-{}", VERSION);
+    let filename = format!("{}.tar.gz", basename);
+
+    // Determine source and install dir
+    let mut install_dir = get_install_dir();
+    let mut source_dir = PathBuf::from(env::var("OUT_DIR").unwrap()).join("source");
+
+    // Avoid issues with paths containing spaces by falling back to using a tempfile.
+    // See https://github.com/jedisct1/libsodium/issues/207
+    if install_dir.to_str().unwrap().contains(" ") {
+        let fallback_path = PathBuf::from("/tmp/").join(&basename).join(&target);
+        install_dir = fallback_path.clone().join("installed");
+        source_dir = fallback_path.clone().join("/source");
+        println!(
+            "cargo:warning=The path to the usual build directory contains spaces and hence \
+             can't be used to build libsodium.  Falling back to use {}.  If running `cargo \
+             clean`, ensure you also delete this fallback directory",
+            fallback_path.to_str().unwrap()
+        );
+    }
+
+    // Create directories
+    fs::create_dir_all(&install_dir).unwrap();
+    fs::create_dir_all(&source_dir).unwrap();
+
+    // Get sources
+    let compressed_file = get_archive(&filename);
+
+    // Unpack the tarball
+    let gz_decoder = Decoder::new(compressed_file).unwrap();
+    let mut archive = Archive::new(gz_decoder);
+    archive.unpack(&source_dir).unwrap();
+    source_dir.push(basename);
+
+    let lib_dir = make_libsodium(&target, &source_dir, &install_dir);
+
+    if target.contains("msvc") {
+        println!("cargo:rustc-link-lib=static=libsodium");
+    } else {
+        println!("cargo:rustc-link-lib=static=sodium");
+    }
+
+    println!(
+        "cargo:rustc-link-search=native={}",
+        lib_dir.to_str().unwrap()
+    );
+
+    let include_dir = source_dir.join("src/libsodium/include");
+
+    println!("cargo:include={}", include_dir.to_str().unwrap());
+    println!("cargo:lib={}", lib_dir.to_str().unwrap());
 }

--- a/testcrate/.gitignore
+++ b/testcrate/.gitignore
@@ -1,0 +1,30 @@
+#### IDEs ####
+### CLion ###
+# CMake
+cmake-build-debug/
+
+### IntelliJ ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### Vim ###
+.sw[a-p]
+.*.sw[a-p]
+Session.vim
+.netrwhist
+*~
+
+### Visual Studio Code ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+.history
+
+#### Languages ####
+### Rust ###
+/target/
+Cargo.lock

--- a/testcrate/Cargo.toml
+++ b/testcrate/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "testcrate"
+build = "build.rs"
+version = "0.0.1"
+
+[dependencies]
+libsodium-sys = { path = "../libsodium-sys" }

--- a/testcrate/build.rs
+++ b/testcrate/build.rs
@@ -1,0 +1,42 @@
+use std::{env, fs};
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let target = env::var("TARGET").unwrap();
+
+    // Skip the test when `SODIUM_LIB_DIR` is set since there is no
+    // build metadata.
+    if let Ok(_) = env::var("SODIUM_LIB_DIR") {
+        return;
+    }
+
+    let include = env::var("DEP_SODIUM_INCLUDE").unwrap();
+
+    let header = fs::read_dir(include)
+        .unwrap()
+        .filter_map(Result::ok)
+        .find(|entry| entry.file_name() == "sodium.h");
+    assert!(
+        header.is_some(),
+        "sodium.h not found in DEP_SODIUM_INCLUDE dir"
+    );
+
+    let lib = env::var("DEP_SODIUM_LIB").unwrap();
+
+    let file_name = if target.contains("msvc") {
+        "libsodium.lib"
+    } else {
+        "libsodium.a"
+    };
+
+    let compiled_lib = fs::read_dir(lib)
+        .unwrap()
+        .filter_map(Result::ok)
+        .find(|e| e.file_name() == file_name);
+
+    assert!(
+        compiled_lib.is_some(),
+        "compiled lib not found in DEP_SODIUM_LIB dir"
+    );
+}

--- a/testcrate/src/lib.rs
+++ b/testcrate/src/lib.rs
@@ -1,0 +1,2 @@
+#[test]
+fn testcrate_builds() {}


### PR DESCRIPTION
Adds `DEP_SODIUM_INCLUDE` & `DEP_SODIUM_LIB` env variable to can be used by dependent crates. In my case, I use it to link against `libsodium` from a c++ library (libzmq) built via cargo.