### PR TITLE
Update CI to test all crates

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -44,7 +44,6 @@ cache:
   - target
 
 build: false
-
 test_script:
-  - cargo test --target %TARGET%
-  - cargo test --release --target %TARGET%
+  - cargo test --all --target %TARGET%
+  - cargo test --all --release --target %TARGET%

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,8 @@ matrix:
       - cargo coveralls --exclude-pattern "$PWD/target/,$PWD/libsodium-sys/src/sodium_bindings.rs"
 
 script:
-  - cargo build --verbose
-  - cargo test --verbose --all
-  - cargo test --verbose --no-default-features --features std
+  - cargo test --all --verbose
+  - cargo test --all --verbose --no-default-features --features std
   - cargo doc
 
 branches:


### PR DESCRIPTION
This will run `cargo test` for all packages in the workspace, including `libsodium-sys`. Note that currently some CI tests are not passing.