### PR TITLE
Fix critical Digest comparison bug

### DIFF
--- a/src/crypto/generichash/digest.rs
+++ b/src/crypto/generichash/digest.rs
@@ -26,7 +26,7 @@ impl PartialEq for Digest {
         if other.len != self.len {
             return false;
         }
-        memcmp(self.as_ref(), self.as_ref())
+        memcmp(self.as_ref(), other.as_ref())
     }
 }
 

--- a/src/crypto/generichash/mod.rs
+++ b/src/crypto/generichash/mod.rs
@@ -191,4 +191,25 @@ mod test {
             assert!(result_hash.as_ref() == expected_hash.as_slice());
         }
     }
+
+    #[test]
+    fn test_digest_equality() {
+        let data1 = [1, 2];
+        let data2 = [3, 4];
+
+        let h1 = {
+            let mut hasher = State::new(32, None).unwrap();
+            hasher.update(&data1).unwrap();
+            hasher.finalize().unwrap()
+        };
+
+        let h2 = {
+            let mut hasher = State::new(32, None).unwrap();
+            hasher.update(&data2).unwrap();
+            hasher.finalize().unwrap()
+        };
+
+        assert_eq!(h1, h1);
+        assert_ne!(h1, h2);
+    }
 }


### PR DESCRIPTION
`PartialEq` implementation for `generichash::Digest` has compared itself to itself