### PR TITLE
Expose libsodium's hexadecimal encoding/decoding helper functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ libsodium-sys = { version = "0.2.5", path = "libsodium-sys" }
 serde = { version = "^1.0.59", default-features = false, optional = true }
 
 [dev-dependencies]
-hex = "0.3"
 serde = "^1.0.59"
 serde_json = "^1.0.17"
 rmp-serde = "^0.13.7"

--- a/src/base64.rs
+++ b/src/base64.rs
@@ -26,8 +26,8 @@ pub fn encode<T: AsRef<[u8]>>(bin: T, variant: Variant) -> String {
     let mut b64 = vec![0; encoded_len];
 
     // SAFETY: `sodium_base64_encoded_len` ensures space for `bin.len()` bytes
-    // and `Variant` contains only valid variant codes.
-    // and `sodium_bin2base64` writes only single byte ASCII characters
+    // and `Variant` contains only valid variant codes
+    // and `sodium_bin2base64` writes only single byte ASCII characters.
     unsafe {
         ffi::sodium_bin2base64(
             b64.as_mut_ptr().cast(),
@@ -43,7 +43,7 @@ pub fn encode<T: AsRef<[u8]>>(bin: T, variant: Variant) -> String {
 
 /// Decodes a Base64 string into a byte sequence using the given variant.
 ///
-/// Fails if an the decoded length overflows
+/// Fails if the decoded length overflows
 /// or if `b64` contains invalid characters.
 pub fn decode<T: AsRef<[u8]>>(b64: T, variant: Variant) -> Result<Vec<u8>, ()> {
     let b64 = b64.as_ref();

--- a/src/crypto/generichash/mod.rs
+++ b/src/crypto/generichash/mod.rs
@@ -106,6 +106,7 @@ impl State {
 #[cfg(test)]
 mod test {
     use super::*;
+    use hex;
     #[cfg(not(feature = "std"))]
     use prelude::*;
 

--- a/src/crypto/hash/sha256.rs
+++ b/src/crypto/hash/sha256.rs
@@ -24,6 +24,7 @@ hash_module!(
 #[cfg(test)]
 mod test {
     use super::*;
+    use hex;
     #[cfg(not(feature = "std"))]
     use prelude::*;
 

--- a/src/crypto/hash/sha512.rs
+++ b/src/crypto/hash/sha512.rs
@@ -24,6 +24,7 @@ hash_module!(
 #[cfg(test)]
 mod test {
     use super::*;
+    use hex;
     #[cfg(not(feature = "std"))]
     use prelude::*;
 

--- a/src/crypto/sign/ed25519.rs
+++ b/src/crypto/sign/ed25519.rs
@@ -237,6 +237,7 @@ impl Default for State {
 #[cfg(test)]
 mod test {
     use super::*;
+    use hex;
 
     #[test]
     fn test_sk_to_pk() {

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -1,0 +1,83 @@
+//! Libsodium hexadecimal encoding/decoding helper functions
+use ffi;
+#[cfg(not(feature = "std"))]
+use prelude::*;
+use std::ptr;
+
+/// Encodes byte sequence into a hexadecimal string.
+///
+/// # Panics
+///
+/// Panics if `2 * bin.len() + 1` overflows.
+pub fn encode<T: AsRef<[u8]>>(bin: T) -> String {
+    let bin = bin.as_ref();
+    let mut hex = vec![0; encoded_len(bin.len()).unwrap()];
+
+    // SAFETY: `sodium_bin2hex` writes `2 * bin.len() + 1`
+    // characters from [0-9a-f] and a nul byte to `bin`.
+    unsafe {
+        ffi::sodium_bin2hex(hex.as_mut_ptr().cast(), hex.len(), bin.as_ptr(), bin.len());
+        hex.pop();
+        String::from_utf8_unchecked(hex)
+    }
+}
+
+fn encoded_len(len: usize) -> Option<usize> {
+    len.checked_mul(2)?.checked_add(1)
+}
+
+/// Parses a hexadecimal string into a byte sequence.
+///
+/// Fails if `hex.len()` is not even or
+/// if `hex` contains characters not in [0-9a-fA-F].
+pub fn decode<T: AsRef<[u8]>>(hex: T) -> Result<Vec<u8>, ()> {
+    let hex = hex.as_ref();
+    let mut bin = vec![0; decoded_len(hex.len())?];
+    let mut bin_len = 0;
+
+    // SAFETY: If `sodium_hex2bin` returns zero,
+    // it has written `bin_len` bytes to `bin`.
+    unsafe {
+        let rc = ffi::sodium_hex2bin(
+            bin.as_mut_ptr(),
+            bin.len(),
+            hex.as_ptr().cast(),
+            hex.len(),
+            ptr::null(),
+            &mut bin_len,
+            ptr::null_mut(),
+        );
+        if rc != 0 {
+            return Err(());
+        }
+        bin.truncate(bin_len);
+        Ok(bin)
+    }
+}
+
+fn decoded_len(len: usize) -> Result<usize, ()> {
+    if len % 2 != 0 {
+        return Err(());
+    }
+
+    Ok(len / 2)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encode() {
+        assert_eq!("".to_string(), encode(b""));
+        assert_eq!("666f6f626172".to_string(), encode(b"foobar"));
+    }
+
+    #[test]
+    fn test_decode() {
+        assert_eq!(Ok(b"".to_vec()), decode(""));
+        assert_eq!(Ok(b"foobar".to_vec()), decode("666F6F626172"));
+        assert_eq!(Err(()), decode("abc"));
+        assert_eq!(Err(()), decode("abxy"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,8 +62,6 @@
 
 extern crate libsodium_sys as ffi;
 
-#[cfg(test)]
-extern crate hex;
 extern crate libc;
 #[cfg(any(test, feature = "serde"))]
 extern crate serde;
@@ -101,6 +99,7 @@ pub fn init() -> Result<(), ()> {
 #[macro_use]
 mod newtype_macros;
 pub mod base64;
+pub mod hex;
 pub mod randombytes;
 pub mod utils;
 pub mod version;


### PR DESCRIPTION
This allows dependent crates to avoid an additional dependency for this and it avoids the development dependency on `hex` for this crate.