### PR TITLE
Fix unused warnings as  is always defined but not always exported

### DIFF
--- a/src/crypto/aead/aead_macros.rs
+++ b/src/crypto/aead/aead_macros.rs
@@ -55,6 +55,7 @@ pub fn gen_key() -> Key {
 /// THREAD SAFETY: `gen_nonce_internal()` is thread-safe provided that you have
 /// called `sodiumoxide::init()` once before using any other function
 /// from sodiumoxide.
+#[allow(unused)]
 fn gen_nonce_internal() -> Nonce {
     let mut n = Nonce([0u8; NONCEBYTES]);
     randombytes_into(&mut n.0);

--- a/src/crypto/aead/aead_macros.rs
+++ b/src/crypto/aead/aead_macros.rs
@@ -50,18 +50,6 @@ pub fn gen_key() -> Key {
     k
 }
 
-/// `gen_nonce_internal` randomly generates a nonce
-///
-/// THREAD SAFETY: `gen_nonce_internal()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
-#[allow(unused)]
-fn gen_nonce_internal() -> Nonce {
-    let mut n = Nonce([0u8; NONCEBYTES]);
-    randombytes_into(&mut n.0);
-    n
-}
-
 /// `seal()` encrypts and authenticates a message `m` together with optional plaintext data `ad`
 /// using a secret key `k` and a nonce `n`. It returns a ciphertext `c`.
 pub fn seal(m: &[u8], ad: Option<&[u8]>, n: &Nonce, k: &Key) -> Vec<u8> {
@@ -173,13 +161,14 @@ pub fn open_detached(c: &mut [u8], ad: Option<&[u8]>, t: &Tag, n: &Nonce, k: &Ke
 #[cfg(test)]
 mod test_m {
     use super::*;
+    use crypto::nonce::gen_random_nonce;
 
     #[test]
     fn test_seal_open() {
         use randombytes::randombytes;
         for i in 0..256usize {
             let k = gen_key();
-            let n = gen_nonce_internal();
+            let n = gen_random_nonce();
             let ad = randombytes(i);
             let m = randombytes(i);
             let c = seal(&m, Some(&ad), &n, &k);
@@ -193,7 +182,7 @@ mod test_m {
         use randombytes::randombytes;
         for i in 0..32usize {
             let k = gen_key();
-            let n = gen_nonce_internal();
+            let n = gen_random_nonce();
             let mut ad = randombytes(i);
             let m = randombytes(i);
             let mut c = seal(&m, Some(&ad), &n, &k);
@@ -217,7 +206,7 @@ mod test_m {
         use randombytes::randombytes;
         for i in 0..256usize {
             let k = gen_key();
-            let n = gen_nonce_internal();
+            let n = gen_random_nonce();
             let ad = randombytes(i);
             let mut m = randombytes(i);
             let m2 = m.clone();
@@ -232,7 +221,7 @@ mod test_m {
         use randombytes::randombytes;
         for i in 0..32usize {
             let k = gen_key();
-            let n = gen_nonce_internal();
+            let n = gen_random_nonce();
             let mut ad = randombytes(i);
             let mut m = randombytes(i);
             let mut t = seal_detached(&mut m, Some(&ad), &n, &k);
@@ -262,7 +251,7 @@ mod test_m {
         use randombytes::randombytes;
         for i in 0..256usize {
             let k = gen_key();
-            let n = gen_nonce_internal();
+            let n = gen_random_nonce();
             let ad = randombytes(i);
             let mut m = randombytes(i);
 

--- a/src/crypto/aead/xchacha20poly1305_ietf.rs
+++ b/src/crypto/aead/xchacha20poly1305_ietf.rs
@@ -8,6 +8,7 @@
 //! For this reason, and if interoperability with other libraries is not a
 //! concern, this is the recommended AEAD construction.
 
+use crypto::nonce::gen_random_nonce;
 use ffi::{
     crypto_aead_xchacha20poly1305_ietf_ABYTES, crypto_aead_xchacha20poly1305_ietf_KEYBYTES,
     crypto_aead_xchacha20poly1305_ietf_NPUBBYTES, crypto_aead_xchacha20poly1305_ietf_decrypt,
@@ -15,6 +16,7 @@ use ffi::{
     crypto_aead_xchacha20poly1305_ietf_encrypt,
     crypto_aead_xchacha20poly1305_ietf_encrypt_detached,
 };
+
 aead_module!(
     crypto_aead_xchacha20poly1305_ietf_encrypt,
     crypto_aead_xchacha20poly1305_ietf_decrypt,
@@ -31,7 +33,7 @@ aead_module!(
 /// called `sodiumoxide::init()` once before using any other function
 /// from sodiumoxide.
 pub fn gen_nonce() -> Nonce {
-    gen_nonce_internal()
+    gen_random_nonce()
 }
 
 #[cfg(test)]

--- a/src/crypto/aead/xchacha20poly1305_ietf.rs
+++ b/src/crypto/aead/xchacha20poly1305_ietf.rs
@@ -79,4 +79,9 @@ mod test {
         let c = seal(m, Some(ad), &n, &k);
         assert_eq!(&c[..], &c_expected[..]);
     }
+
+    #[test]
+    fn test_nonce_length() {
+        assert_eq!(192 / 8, gen_nonce().as_ref().len());
+    }
 }

--- a/src/crypto/box_/curve25519xsalsa20poly1305.rs
+++ b/src/crypto/box_/curve25519xsalsa20poly1305.rs
@@ -5,10 +5,10 @@
 //! This function is conjectured to meet the standard notions of privacy and
 //! third-party unforgeability.
 
+use crypto::nonce::gen_random_nonce;
 use ffi;
 #[cfg(not(feature = "std"))]
 use prelude::*;
-use randombytes::randombytes_into;
 
 /// Number of bytes in a `Seed`.
 pub const SEEDBYTES: usize = ffi::crypto_box_curve25519xsalsa20poly1305_SEEDBYTES as usize;
@@ -118,9 +118,7 @@ pub fn keypair_from_seed(seed: &Seed) -> (PublicKey, SecretKey) {
 /// called `sodiumoxide::init()` once before using any other function
 /// from sodiumoxide.
 pub fn gen_nonce() -> Nonce {
-    let mut n = [0; NONCEBYTES];
-    randombytes_into(&mut n);
-    Nonce(n)
+    gen_random_nonce()
 }
 
 /// `seal()` encrypts and authenticates a message `m` using the senders secret key `sk`,
@@ -751,6 +749,11 @@ mod test {
             round_trip(sk);
             round_trip(n);
         }
+    }
+
+    #[test]
+    fn test_nonce_length() {
+        assert_eq!(192 / 8, gen_nonce().as_ref().len());
     }
 }
 

--- a/src/crypto/nonce.rs
+++ b/src/crypto/nonce.rs
@@ -1,0 +1,22 @@
+use randombytes::randombytes_into;
+
+/// The `Nonce` trait allows for generic construction
+/// from an array of bytes, e.g. to generically create random nonces.
+pub trait Nonce {
+    type Bytes: Default + AsMut<[u8]>;
+    fn from_bytes(Self::Bytes) -> Self;
+}
+
+/// `gen_random_nonce()` randomly generates a nonce for symmetric encryption
+///
+/// THREAD SAFETY: `gen_random_nonce()` is thread-safe provided that you have
+/// called `sodiumoxide::init()` once before using any other function
+/// from sodiumoxide.
+///
+/// NOTE: When using primitives with short nonces (e.g. salsa20, salsa208, salsa2012)
+/// do not use random nonces since the probability of nonce-collision is not negligible
+pub fn gen_random_nonce<N: Nonce>() -> N {
+    let mut n = N::Bytes::default();
+    randombytes_into(n.as_mut());
+    N::from_bytes(n)
+}

--- a/src/crypto/secretbox/xsalsa20poly1305.rs
+++ b/src/crypto/secretbox/xsalsa20poly1305.rs
@@ -5,6 +5,7 @@
 //! This function is conjectured to meet the standard notions of privacy and
 //! authenticity.
 
+use crypto::nonce::gen_random_nonce;
 use ffi;
 #[cfg(not(feature = "std"))]
 use prelude::*;
@@ -58,9 +59,7 @@ pub fn gen_key() -> Key {
 /// called `sodiumoxide::init()` once before using any other function
 /// from sodiumoxide.
 pub fn gen_nonce() -> Nonce {
-    let mut nonce = [0; NONCEBYTES];
-    randombytes_into(&mut nonce);
-    Nonce(nonce)
+    gen_random_nonce()
 }
 
 /// `seal()` encrypts and authenticates a message `m` using a secret key `k` and a
@@ -323,6 +322,11 @@ mod test {
             round_trip(k);
             round_trip(n);
         }
+    }
+
+    #[test]
+    fn test_nonce_length() {
+        assert_eq!(192 / 8, gen_nonce().as_ref().len());
     }
 }
 

--- a/src/crypto/stream/stream_macros.rs
+++ b/src/crypto/stream/stream_macros.rs
@@ -38,21 +38,6 @@ pub fn gen_key() -> Key {
     Key(key)
 }
 
-/// `gen_nonce_internal()` randomly generates a nonce for symmetric encryption
-///
-/// THREAD SAFETY: `gen_nonce_internal()` is thread-safe provided that you have
-/// called `sodiumoxide::init()` once before using any other function
-/// from sodiumoxide.
-///
-/// NOTE: When using primitives with short nonces (e.g. salsa20, salsa208, salsa2012)
-/// do not use random nonces since the probability of nonce-collision is not negligible
-#[allow(unused)]
-fn gen_nonce_internal() -> Nonce {
-    let mut nonce = [0; NONCEBYTES];
-    randombytes_into(&mut nonce);
-    Nonce(nonce)
-}
-
 /// `stream()` produces a `len`-byte stream `c` as a function of a
 /// secret key `k` and a nonce `n`.
 pub fn stream(len: usize,
@@ -155,13 +140,14 @@ pub fn stream_xor_ic_inplace(m: &mut [u8],
 #[cfg(test)]
 mod test_m {
     use super::*;
+    use crypto::nonce::gen_random_nonce;
 
     #[test]
     fn test_encrypt_decrypt() {
         use randombytes::randombytes;
         for i in 0..1024usize {
             let k = gen_key();
-            let n = gen_nonce_internal();
+            let n = gen_random_nonce();
             let m = randombytes(i);
             let c = stream_xor(&m, &n, &k);
             let m2 = stream_xor(&c, &n, &k);
@@ -174,7 +160,7 @@ mod test_m {
         use randombytes::randombytes;
         for i in 0..1024usize {
             let k = gen_key();
-            let n = gen_nonce_internal();
+            let n = gen_random_nonce();
             let m = randombytes(i);
             let mut c = m.clone();
             let s = stream(c.len(), &n, &k);
@@ -191,7 +177,7 @@ mod test_m {
         use randombytes::randombytes;
         for i in 0..1024usize {
             let k = gen_key();
-            let n = gen_nonce_internal();
+            let n = gen_random_nonce();
             let mut m = randombytes(i);
             let mut c = m.clone();
             let s = stream(c.len(), &n, &k);
@@ -208,7 +194,7 @@ mod test_m {
         use randombytes::randombytes;
         for i in 0..1024usize {
             let k = gen_key();
-            let n = gen_nonce_internal();
+            let n = gen_random_nonce();
             let m = randombytes(i);
             let c = stream_xor(&m, &n, &k);
             let c_ic = stream_xor_ic(&m, &n, 0, &k);
@@ -221,7 +207,7 @@ mod test_m {
         use randombytes::randombytes;
         for i in 0..1024usize {
             let k = gen_key();
-            let n = gen_nonce_internal();
+            let n = gen_random_nonce();
             for j in 0..10 {
                 let mut m = randombytes(i);
                 let c = stream_xor_ic(&m, &n, j, &k);
@@ -237,7 +223,7 @@ mod test_m {
         use test_utils::round_trip;
         for _ in 0..1024usize {
             let k = gen_key();
-            let n = gen_nonce_internal();
+            let n: Nonce = gen_random_nonce();
             round_trip(k);
             round_trip(n);
         }
@@ -256,7 +242,7 @@ mod bench_m {
     #[bench]
     fn bench_stream(b: &mut test::Bencher) {
         let k = gen_key();
-        let n = gen_nonce_internal();
+        let n = gen_random_nonce();
         b.iter(|| {
             for size in BENCH_SIZES.iter() {
                 stream(*size, &n, &k);

--- a/src/crypto/stream/stream_macros.rs
+++ b/src/crypto/stream/stream_macros.rs
@@ -46,6 +46,7 @@ pub fn gen_key() -> Key {
 ///
 /// NOTE: When using primitives with short nonces (e.g. salsa20, salsa208, salsa2012)
 /// do not use random nonces since the probability of nonce-collision is not negligible
+#[allow(unused)]
 fn gen_nonce_internal() -> Nonce {
     let mut nonce = [0; NONCEBYTES];
     randombytes_into(&mut nonce);

--- a/src/crypto/stream/xchacha20.rs
+++ b/src/crypto/stream/xchacha20.rs
@@ -25,3 +25,13 @@ stream_module!(
 pub fn gen_nonce() -> Nonce {
     gen_random_nonce()
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_nonce_length() {
+        assert_eq!(192 / 8, gen_nonce().as_ref().len());
+    }
+}

--- a/src/crypto/stream/xchacha20.rs
+++ b/src/crypto/stream/xchacha20.rs
@@ -3,6 +3,7 @@
 //! This cipher is conjectured to meet the standard notion of
 //! unpredictability.
 
+use crypto::nonce::gen_random_nonce;
 use ffi::{
     crypto_stream_xchacha20, crypto_stream_xchacha20_KEYBYTES, crypto_stream_xchacha20_NONCEBYTES,
     crypto_stream_xchacha20_xor, crypto_stream_xchacha20_xor_ic,
@@ -22,5 +23,5 @@ stream_module!(
 /// called `sodiumoxide::init()` once before using any other function
 /// from sodiumoxide.
 pub fn gen_nonce() -> Nonce {
-    gen_nonce_internal()
+    gen_random_nonce()
 }

--- a/src/crypto/stream/xsalsa20.rs
+++ b/src/crypto/stream/xsalsa20.rs
@@ -115,4 +115,9 @@ mod test {
         ];
         assert!(c[32..] == c_expected[..]);
     }
+
+    #[test]
+    fn test_nonce_length() {
+        assert_eq!(192 / 8, gen_nonce().as_ref().len());
+    }
 }

--- a/src/crypto/stream/xsalsa20.rs
+++ b/src/crypto/stream/xsalsa20.rs
@@ -3,6 +3,7 @@
 //! This cipher is conjectured to meet the standard notion of
 //! unpredictability.
 
+use crypto::nonce::gen_random_nonce;
 use ffi::{
     crypto_stream_xsalsa20, crypto_stream_xsalsa20_KEYBYTES, crypto_stream_xsalsa20_NONCEBYTES,
     crypto_stream_xsalsa20_xor, crypto_stream_xsalsa20_xor_ic,
@@ -22,7 +23,7 @@ stream_module!(
 /// called `sodiumoxide::init()` once before using any other function
 /// from sodiumoxide.
 pub fn gen_nonce() -> Nonce {
-    gen_nonce_internal()
+    gen_random_nonce()
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,7 @@ pub mod crypto {
     pub mod generichash;
     pub mod hash;
     pub mod kx;
+    mod nonce;
     pub mod onetimeauth;
     pub mod pwhash;
     pub mod scalarmult;

--- a/src/newtype_macros.rs
+++ b/src/newtype_macros.rs
@@ -286,6 +286,12 @@ macro_rules! new_type {
             }
 
         }
+        impl crate::crypto::nonce::Nonce for $name {
+            type Bytes = [u8; $bytes];
+            fn from_bytes(bytes: Self::Bytes) -> Self {
+                Self(bytes)
+            }
+        }
         impl ::std::fmt::Debug for $name {
             fn fmt(&self,
                    formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {


### PR DESCRIPTION
Warnings like https://travis-ci.org/sodiumoxide/sodiumoxide/jobs/615562099#L255