### PR TITLE
RFC: Deny Clippy warnings in CI jobs to catch more issue automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     before_script:
       - rustup component add clippy
     script:
-      - cargo clippy --all --tests
+      - cargo clippy --all --lib --tests -- --deny warnings
   - name: coverage
     os: linux
     rust: stable


### PR DESCRIPTION
At $DAYJOB, we run the CI with `cargo clippy -- --deny warnings` to essentially avoid having them in the code base but not making the edit-build-test cycle harder as with a `lib.rs`-based configuration.