### PR TITLE
Use cc crate to determine CFLAGS for building libsodium

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
     script:
       - cargo install cargo-travis --debug || echo "cargo-travis has been already installed"
       - mkdir target # fix for cargo-coveralls
-      - cargo coveralls
+      - cargo coveralls --exclude-pattern "$PWD/target/"
 
 script:
   - cargo build --verbose

--- a/libsodium-sys/build.rs
+++ b/libsodium-sys/build.rs
@@ -152,10 +152,9 @@ fn make_libsodium(target: &str, source_dir: &Path, install_dir: &Path) -> PathBu
     use std::{fs, process::Command, str};
 
     // Decide on CC, CFLAGS and the --host configure argument
-    let build = cc::Build::new();
-    let mut compiler = build.get_compiler().path().to_str().unwrap().to_string();
-    let mut cflags = env::var("CFLAGS").unwrap_or(String::default());
-    cflags += " -O2";
+    let build_compiler = cc::Build::new().get_compiler();
+    let mut compiler = build_compiler.path().to_str().unwrap().to_string();
+    let mut cflags = build_compiler.cflags_env().into_string().unwrap();
     let host_arg;
     let cross_compiling;
     let help;


### PR DESCRIPTION
Determine the `CFLAGS` passed to libsodium's configure script via the `cc` crate automatically picks up environment variables like `CFLAGS` and `TARGET_CFLAGS`, handles the differences between
release and debug builds and finally provides `CFLAGS` that interoperate well when linking the result into a Rust binary by requesting per-function sections for example.

It is also more consistent with how we already determine the compiler command itself via for example consider `TARGET_CC` whereas our own `CFLAGS` logic did not consider `TARGET_CFLAGS`.