### PR TITLE
Make upcoming Clippy 1.40 happy

### DIFF
--- a/testcrate/build.rs
+++ b/testcrate/build.rs
@@ -7,7 +7,7 @@ fn main() {
 
     // Skip the test when `SODIUM_LIB_DIR` is set since there is no
     // build metadata.
-    if let Ok(_) = env::var("SODIUM_LIB_DIR") {
+    if env::var("SODIUM_LIB_DIR").is_ok() {
         return;
     }
 


### PR DESCRIPTION
The Clippy version shipped with the upcoming 1.40 release will have a few new complaints about our build scripts which this commit fixes.