### PR TITLE
RFC: Try to simplify build options for libsodium

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,7 +21,6 @@ environment:
   - TARGET: x86_64-pc-windows-msvc
     RUST_CHANNEL: stable
     VCPKG_TARGET: x64-windows
-    SODIUM_USE_PKG_CONFIG: 1
     VCPKGRS_DYNAMIC: 1
     RUST_BACKTRACE: 1
 
@@ -33,7 +32,7 @@ install:
       cmd.exe /c .\rustup-init.exe -y --profile minimal --default-host "$env:TARGET" --default-toolchain "$env:RUST_CHANNEL" 2`>`&1
       $env:PATH += ";$env:USERPROFILE\.cargo\bin"
 
-      If ($env:SODIUM_USE_PKG_CONFIG -eq '1') {
+      If ($env:VCPKG_TARGET -ne '') {
         # Install libsodium via vcpkg
         vcpkg install "libsodium:$env:VCPKG_TARGET"
       }
@@ -46,5 +45,5 @@ cache:
 
 build: false
 test_script:
-  - cargo test --all --target %TARGET%
-  - cargo test --all --release --target %TARGET%
+  - cargo test --all --features use-vcpkg --target %TARGET%
+  - cargo test --all --features use-vcpkg --release --target %TARGET%

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
 
 script:
   - cargo test --all --verbose
-  - cargo test --all --verbose --no-default-features --features std
+  - cargo test --all --verbose --no-default-features --features std --features bundled
   - cargo doc
 
 branches:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,9 @@ serde_json = "^1.0.17"
 rmp-serde = "^0.13.7"
 
 [features]
+default = ["serde", "std", "bundled"]
 benchmarks = []
 std = []
-default = ["serde", "std"]
-use-pkg-config = ["libsodium-sys/use-pkg-config"]
+bundled = ["libsodium-sys/cc"]
+use-pkg-config = ["libsodium-sys/pkg-config"]
+use-vcpkg = ["libsodium-sys/vcpkg"]

--- a/README.md
+++ b/README.md
@@ -28,13 +28,6 @@ Rust >= 1.36.0 is required because of mem::MaybeUninit.
 
 ## Basic usage
 
-### Cloning
-```
-git clone https://github.com/sodiumoxide/sodiumoxide.git
-cd sodiumoxide
-git submodule update --init --recursive
-```
-
 ### Building
 ```
 cargo build
@@ -67,15 +60,19 @@ Although it is highly recommended to use the default way with the pinned version
 * link it against the library installed on your system
 * link it against a precompiled library that you built on your own
 
-You can do this by setting environment variables.
+You can do this by enabling features and setting environment variables.
 
 |Name|Description|Example value|Notes|
 | :- | :-------- | :---------- | :-- |
+|`use-pkg-config`|Cargo feature to enable probing via `pkg-config`|||
+|`use-vcpkg`|Cargo feature to enable probing via `vcpkg`|||
 |`SODIUM_LIB_DIR`|Where to find a precompiled library|`/usr/lib/x86_64-linux-gnu/`|The value should be set to the directory containing `.so`,`.a`,`.la`,`.dll` or `.lib`|
-|`SODIUM_SHARED`|Tell `rustc` to link the library dynamically|`1`|Works only with `SODIUM_LIB_DIR`. We check only the presence|
-|`SODIUM_USE_PKG_CONFIG`|Tell build.rs to find system library using pkg-config or vcpkg|`1`|We check only the presence|
-|`SODIUM_DISABLE_PIE`|Build with `--disable-pie`|`1`|Certain situations may require building libsodium configured with `--disable-pie`. Useful for !Windows only and when building libsodium from source. We check only the presence|
-|`VCPKGRS_DYNAMIC`|Tell `vcpkg` to find libsodium|`1`|Usefull for Windows only with `SODIUM_USE_PKG_CONFIG`. More info: https://docs.rs/vcpkg/|
+|`SODIUM_DYNAMIC`|Tell `rustc` to link the library dynamically|`1`|Works only with `SODIUM_LIB_DIR` and `pkg-config`. We check only the presence|
+|`SODIUM_STATIC`|Tell `rustc` to link the library statically|`1`|Works only with `SODIUM_LIB_DIR` and `pkg-config`. We check only the presence|
+|`SODIUM_NO_PKG_CONFIG`|Tell `pkg-config` to ignore libsodium even if found|`1`||
+|`VCPKGRS_DYNAMIC`|Tell `vcpkg` to link DLL builds|`1`|Usefull for Windows only with `vcpkg`. More info: https://docs.rs/vcpkg/|
+|`VCPKGRS_NO_SODIUM`|Tell `vcpkg` to ignore libsodium even if found|`1`||
+|`SODIUM_DISABLE_PIE`|Build with `--disable-pie`|`1`|Certain situations may require building libsodium configured with `--disable-pie`. Useful for Windows only and when building libsodium from source. We check only the presence|
 
 ### Examples on *nix
 
@@ -84,8 +81,7 @@ You can do this by setting environment variables.
 (Ubuntu: `apt install pkg-config`, OSX: `brew install pkg-config`, ...)
 
 ```
-export SODIUM_USE_PKG_CONFIG=1
-cargo build
+cargo build --features use-pkg-config
 ```
 
 #### Using precompiled library
@@ -94,7 +90,7 @@ See https://download.libsodium.org/doc/installation.
 
 ```
 export SODIUM_LIB_DIR=/home/user/libsodium-1.0.18/release/lib/
-export SODIUM_SHARED=1
+export SODIUM_DYNAMIC=1
 cargo build
 ```
 
@@ -106,9 +102,8 @@ See https://github.com/Microsoft/vcpkg.
 
 ```
 C:\Users\user\dev\vcpkg\vcpkg.exe install libsodium --triplet x64-windows
-set SODIUM_USE_PKG_CONFIG=1
 set VCPKGRS_DYNAMIC=1
-cargo build
+cargo build --features use-vcpkg
 ```
 
 ## Optional features
@@ -223,9 +218,12 @@ Sodiumoxide has been tested on:
 
 File bugs in the issue tracker
 
-Master git repository
-
-    git clone https://github.com/sodiumoxide/sodiumoxide.git
+Clone repository using
+```
+git clone https://github.com/sodiumoxide/sodiumoxide.git
+cd sodiumoxide
+git submodule update --init --recursive
+```
 
 ## License
 

--- a/libsodium-sys/Cargo.toml
+++ b/libsodium-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["dnaq"]
-build = "build.rs"
+edition = "2018"
 description = "FFI binding to libsodium"
 documentation = "https://sodiumoxide.github.io/sodiumoxide"
 keywords = ["libsodium", "NaCl", "crypto"]
@@ -15,20 +15,16 @@ version = "0.2.5"
 travis-ci = { repository = "sodiumoxide/sodiumoxide" }
 
 [build-dependencies]
-pkg-config = "0.3"
+pkg-config = { version = "0.3", optional = true }
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]
-libc = { version = "0.2" , default-features = false }
-vcpkg = "0.2"
+vcpkg = { version = "0.2", optional = true }
 
 [target.'cfg(not(target_env = "msvc"))'.build-dependencies]
-cc = "1.0"
+cc = { version = "1.0", optional = true }
 
 [dependencies]
 libc = { version = "0.2" , default-features = false }
 
 [lib]
 name = "libsodium_sys"
-
-[features]
-use-pkg-config = []


### PR DESCRIPTION
* Make sure we use the target when deciding on what to probe, link or build.
* Make it easy to persistently enable pkg-config and vcpkg via feature flag.
* Align environment variables with pkg-config and vcpkg bindings.

Closes #377 
Closes #359 

This is my first try that does _not_ take any precautions w.r.t. backwards compatibility but sticks to the idea that the bundled build is the default while making it easy to persistently enable pkg-config or vcpkg usage. I also separated linking prebuilt libraries and building from source as this simplifies building from source a bit.