### PR TITLE
Avoid ptr_cast feature as it was not yet stable in Rust 1.36.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,11 @@ matrix:
       - cargo install cargo-travis --debug || echo "cargo-travis has been already installed"
       - mkdir target # fix for cargo-coveralls
       - cargo coveralls --exclude-pattern "$PWD/target/,$PWD/libsodium-sys/src/sodium_bindings.rs"
+  - name: minimum-supported-rust-version
+    os: linux
+    rust: 1.36.0
+    script:
+      - cargo check --all --verbose
 
 script:
   - cargo test --all --verbose

--- a/libsodium-sys/build.rs
+++ b/libsodium-sys/build.rs
@@ -373,7 +373,7 @@ fn build_libsodium() {
         Command::new("xcopy")
             .arg("libsodium")
             .arg(&source_dir)
-            .args(&["/s", "/e", "/i", "/q"])
+            .args(&["/s", "/e", "/i", "/q", "/y"])
             .status()
     } else {
         Command::new("cp")

--- a/src/base64.rs
+++ b/src/base64.rs
@@ -30,7 +30,7 @@ pub fn encode<T: AsRef<[u8]>>(bin: T, variant: Variant) -> String {
     // and `sodium_bin2base64` writes only single byte ASCII characters.
     unsafe {
         ffi::sodium_bin2base64(
-            b64.as_mut_ptr().cast(),
+            b64.as_mut_ptr() as *mut _,
             b64.len(),
             bin.as_ptr(),
             bin.len(),
@@ -59,7 +59,7 @@ pub fn decode<T: AsRef<[u8]>>(b64: T, variant: Variant) -> Result<Vec<u8>, ()> {
         let rc = ffi::sodium_base642bin(
             bin.as_mut_ptr(),
             bin.len(),
-            b64.as_ptr().cast(),
+            b64.as_ptr() as *const _,
             b64.len(),
             ptr::null(),
             &mut bin_len,

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -16,7 +16,12 @@ pub fn encode<T: AsRef<[u8]>>(bin: T) -> String {
     // SAFETY: `sodium_bin2hex` writes `2 * bin.len() + 1`
     // characters from [0-9a-f] and a nul byte to `bin`.
     unsafe {
-        ffi::sodium_bin2hex(hex.as_mut_ptr().cast(), hex.len(), bin.as_ptr(), bin.len());
+        ffi::sodium_bin2hex(
+            hex.as_mut_ptr() as *mut _,
+            hex.len(),
+            bin.as_ptr(),
+            bin.len(),
+        );
         hex.pop();
         String::from_utf8_unchecked(hex)
     }
@@ -41,7 +46,7 @@ pub fn decode<T: AsRef<[u8]>>(hex: T) -> Result<Vec<u8>, ()> {
         let rc = ffi::sodium_hex2bin(
             bin.as_mut_ptr(),
             bin.len(),
-            hex.as_ptr().cast(),
+            hex.as_ptr() as *const _,
             hex.len(),
             ptr::null(),
             &mut bin_len,


### PR DESCRIPTION
Also adds a Travis CI job to check building against the minimum supported Rust version, i.e. 1.36.0, and fixes the `xcopy` flags again to allow overriding files in the target directory.