### PR TITLE
Support selecting static builds for windows only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,4 +37,9 @@ rmp-serde = "^0.13.7"
 benchmarks = []
 std = []
 default = ["serde", "std"]
+# use-pkg-config should be deprecated in the future and become the default
 use-pkg-config = ["libsodium-sys/use-pkg-config"]
+# always force a static build, even if use-pkg-config becomes the default
+static = ["libsodium-sys/static"]
+# only force a static build on windows
+static-windows = ["libsodium-sys/static-windows"]

--- a/libsodium-sys/Cargo.toml
+++ b/libsodium-sys/Cargo.toml
@@ -31,4 +31,9 @@ libc = { version = "0.2" , default-features = false }
 name = "libsodium_sys"
 
 [features]
+# use-pkg-config should be deprecated in the future and become the default
 use-pkg-config = []
+# always force a static build, even if use-pkg-config becomes the default
+static = []
+# only force a static build on windows
+static-windows = []

--- a/libsodium-sys/build.rs
+++ b/libsodium-sys/build.rs
@@ -34,7 +34,7 @@ fn main() {
 
     let lib_dir_isset = env::var("SODIUM_LIB_DIR").is_ok();
     let use_pkg_isset = if cfg!(feature = "use-pkg-config") {
-        true
+        cfg!(not(feature = "static")) && cfg!(not(all(feature = "static-windows", windows)))
     } else {
         env::var("SODIUM_USE_PKG_CONFIG").is_ok()
     };


### PR DESCRIPTION
This change allows a project to link dynamically on all platforms except windows and optionally supports static builds on all systems with a feature.

The reason `static-windows` is slightly awkward is due to https://github.com/rust-lang/cargo/issues/1197, meaning if `[target.'cfg(windows)'.dependencies]` enables the `sodiumoxide/static` feature it would be enabled for all targets including linux, and the other way around if `cfg(not(windows))` enables `sodiumoxide/use-pkg-config` it would be enabled for windows as well.

The `static` feature is necessary because cargo features are strictly additive and it's impossible to express "default to dynamic linking and allow opting into static builds" without messing around with `--no-default-features`.

## Before

This is what I currently do in my projects:
```
[features]
default = ["dynamic-libsodium"]
dynamic-libsodium = ["sodiumoxide/use-pkg-config"]
```
| | Linux | MacOS | Windows |
| --- | --- | --- | --- |
| `cargo build` | dynamic | dynamic | **error** |
| `cargo build --no-default-features` | static | static | static |

## After

Intended usage after this patch would look like this:
```
[features]
static = ["sodiumoxide/static"]

[dependencies]
sodiumoxide = { version="0.2.5", features=["use-pkg-config, "static-windows"] }
```

| | Linux | MacOS | Windows |
| --- | --- | --- | --- |
| `cargo build` | dynamic | dynamic | static |
| `cargo build --features static` | static | static | static |

This change is explicitly non-breaking but prepares for a future breaking change that would allow us to resolve #411 by simply making use-pkg-config the default behavior. Also relates to #359.

Due to features being additive a library crate should never enable the `static` feature.