### PR TITLE
Show a more helpful error message if pkg-config failed to execute

### DIFF
--- a/libsodium-sys/build.rs
+++ b/libsodium-sys/build.rs
@@ -112,7 +112,23 @@ fn find_libsodium_pkg() {
             }
         }
         Err(e) => {
-            panic!(format!("Error: {:?}", e));
+            panic!(
+                "
+Failed to run pkg-config:
+{:?}
+
+You can try fixing this by installing pkg-config:
+
+    # On Ubuntu
+    sudo apt install pkg-config
+    # On Arch Linux
+    sudo pacman -S pkgconf
+    # On Fedora
+    sudo dnf install pkgconf-pkg-config
+
+",
+                e
+            );
         }
     }
 }


### PR DESCRIPTION
## Before
```
error: failed to run custom build command for `libsodium-sys v0.2.6 (/sodiumoxide/libsodium-sys)`

Caused by:
  process didn't exit successfully: `/sodiumoxide/target/debug/build/libsodium-sys-e518d918bc369c57/build-script-build` (exit code: 101)
--- stdout
cargo:rerun-if-env-changed=SODIUM_LIB_DIR
cargo:rerun-if-env-changed=SODIUM_SHARED
cargo:rerun-if-env-changed=SODIUM_USE_PKG_CONFIG
cargo:rerun-if-env-changed=SODIUM_DISABLE_PIE
cargo:rerun-if-env-changed=LIBSODIUM_NO_PKG_CONFIG
cargo:rerun-if-env-changed=PKG_CONFIG
cargo:rerun-if-env-changed=LIBSODIUM_STATIC
cargo:rerun-if-env-changed=LIBSODIUM_DYNAMIC
cargo:rerun-if-env-changed=PKG_CONFIG_ALL_STATIC
cargo:rerun-if-env-changed=PKG_CONFIG_ALL_DYNAMIC
cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64-unknown-linux-gnu
cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64_unknown_linux_gnu
cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
cargo:rerun-if-env-changed=PKG_CONFIG_PATH
cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64-unknown-linux-gnu
cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64_unknown_linux_gnu
cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64-unknown-linux-gnu
cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64_unknown_linux_gnu
cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR

--- stderr
thread 'main' panicked at 'Error: Command { command: "\"pkg-config\" \"--libs\" \"--cflags\" \"libsodium\"", cause: Os { code: 2, kind: NotFound, message: "No such file or directory" } }', libsodium-sys/build.rs:115:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## After
```
error: failed to run custom build command for `libsodium-sys v0.2.6 (/sodiumoxide/libsodium-sys)`

Caused by:
  process didn't exit successfully: `/sodiumoxide/target/debug/build/libsodium-sys-e518d918bc369c57/build-script-build` (exit code: 101)
--- stdout
cargo:rerun-if-env-changed=SODIUM_LIB_DIR
cargo:rerun-if-env-changed=SODIUM_SHARED
cargo:rerun-if-env-changed=SODIUM_USE_PKG_CONFIG
cargo:rerun-if-env-changed=SODIUM_DISABLE_PIE
cargo:rerun-if-env-changed=LIBSODIUM_NO_PKG_CONFIG
cargo:rerun-if-env-changed=PKG_CONFIG
cargo:rerun-if-env-changed=LIBSODIUM_STATIC
cargo:rerun-if-env-changed=LIBSODIUM_DYNAMIC
cargo:rerun-if-env-changed=PKG_CONFIG_ALL_STATIC
cargo:rerun-if-env-changed=PKG_CONFIG_ALL_DYNAMIC
cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64-unknown-linux-gnu
cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64_unknown_linux_gnu
cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
cargo:rerun-if-env-changed=PKG_CONFIG_PATH
cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64-unknown-linux-gnu
cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64_unknown_linux_gnu
cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64-unknown-linux-gnu
cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64_unknown_linux_gnu
cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR

--- stderr
thread 'main' panicked at '
Failed to run pkg-config:
Command { command: "\"pkg-config\" \"--libs\" \"--cflags\" \"libsodium\"", cause: Os { code: 2, kind: NotFound, message: "No such file or directory" } }

You can try fixing this by installing pkg-config:

    # On Ubuntu
    sudo apt install pkg-config
    # On Arch Linux
    sudo pacman -S pkgconf
    # On Fedora
    sudo dnf install pkgconf-pkg-config

', libsodium-sys/build.rs:115:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This is inspired by openssl-sys, which does something [similar](https://github.com/sfackler/rust-openssl/blob/e796b76e473ff244c2eb0545000361ce9a20b0da/openssl-sys/build/main.rs#L140-L163).