### PR TITLE
Remove extra github action job

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -142,16 +142,3 @@ jobs:
     steps:
     - name: Mark the job as successful
       run: exit 0
-
-  end-failure:
-    name: bors build finished
-    if: "!success()"
-    runs-on: ubuntu-latest
-    needs:
-    - test
-    - fmt
-    - clippy
-    - cross
-    steps:
-    - name: Mark the job as a failure
-      run: exit 1


### PR DESCRIPTION
It's not needed, since the "skipped" task is counted as a failure.