### PR TITLE
Do not call Vec::set_len before the data is initialised

### DIFF
--- a/src/crypto/box_/curve25519xsalsa20poly1305.rs
+++ b/src/crypto/box_/curve25519xsalsa20poly1305.rs
@@ -246,7 +246,6 @@ pub fn seal_precomputed(m: &[u8], n: &Nonce, k: &PrecomputedKey) -> Vec<u8> {
     let clen = m.len() + MACBYTES;
     let mut c = Vec::with_capacity(clen);
     unsafe {
-        c.set_len(clen);
         ffi::crypto_box_easy_afternm(
             c.as_mut_ptr(),
             m.as_ptr(),
@@ -254,6 +253,7 @@ pub fn seal_precomputed(m: &[u8], n: &Nonce, k: &PrecomputedKey) -> Vec<u8> {
             n.0.as_ptr(),
             k.0.as_ptr(),
         );
+        c.set_len(clen);
     }
     c
 }
@@ -285,20 +285,20 @@ pub fn open_precomputed(c: &[u8], n: &Nonce, k: &PrecomputedKey) -> Result<Vec<u
     }
     let mlen = c.len() - MACBYTES;
     let mut m = Vec::with_capacity(mlen);
-    let ret = unsafe {
-        m.set_len(mlen);
-        ffi::crypto_box_open_easy_afternm(
+    unsafe {
+        let ret = ffi::crypto_box_open_easy_afternm(
             m.as_mut_ptr(),
             c.as_ptr(),
             c.len() as u64,
             n.0.as_ptr(),
             k.0.as_ptr(),
-        )
-    };
-    if ret == 0 {
-        Ok(m)
-    } else {
-        Err(())
+        );
+        if ret == 0 {
+            m.set_len(mlen);
+            Ok(m)
+        } else {
+            Err(())
+        }
     }
 }
 


### PR DESCRIPTION
While this should not be exploitable as `u8` is `Copy` and hence is not dropped, it seems prudent to only change the length of a `Vec` after the data has been initialised via an FFI call (as is already done in the other places that use `Vec::set_len`).