### PR TITLE
impl Zeroize for `new_type!`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,10 @@ members = ["libsodium-sys", "testcrate"]
 
 [dependencies]
 ed25519 = { version = "1", default-features = false }
-libc = { version = "^0.2.41" , default-features = false }
+libc = { version = "^0.2.41", default-features = false }
 libsodium-sys = { version = "0.2.5", path = "libsodium-sys" }
 serde = { version = "^1.0.59", default-features = false, optional = true }
+zeroize = { version = "^1.2.0" }
 
 [dev-dependencies]
 serde = "^1.0.59"

--- a/src/newtype_macros.rs
+++ b/src/newtype_macros.rs
@@ -215,6 +215,12 @@ macro_rules! new_type {
                 memzero(&mut self.0);
             }
         }
+        impl zeroize::Zeroize for $name {
+            fn zeroize(&mut self) {
+                use utils::memzero;
+                memzero(&mut self.0);
+            }
+        }
         impl ::std::fmt::Debug for $name {
             fn fmt(&self,
                    formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {


### PR DESCRIPTION
This PR is not adding any new functionality, it simply exposes what is already available in order to work with the [`secrecy` crate](https://crates.io/crates/secrecy). Concrete, it implements the [`Zeroize` trait](https://crates.io/crates/zeroize) for all `new_type!` structs. This allows applications to wrap e.g. secret keys in `Secret`:

```rust
let (public_key, secret_key) = sodiumoxide::crypto::box_:gen_keypair();
let secret_key = secrecy::Secret::new(secret_key);
```