### PR TITLE
Bump version (0.2.7) and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.2.7 (Jun 21, 2021)
+
+* Add ed25519 to x25519 conversion methods (#456)
+* Update prebuilt windows binaries to those published at 2020-12-31 at libsodium.org
+* Update libsodium submodule to stable branch commit 8acd227
+* Fix no_std build
+* Expose the sodium_pad and sodium_unpad functions
+* Switch from using xcopy to using walkdir + fs::copy in build script
+* Add support for the AES256-GCM AEAD construction
+* Expose randombytes_buf_deterministic function (#431)
+
 # 0.2.6 (Jul 19, 2020)
 
 * Remove support for using vcpkg for windows (msvc) builds since it was undertested

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "sodiumoxide"
 readme = "README.md"
 repository = "https://github.com/sodiumoxide/sodiumoxide"
 categories = ["cryptography"]
-version = "0.2.6"
+version = "0.2.7"
 exclude = [
     "**/.gitignore",
     ".github/*"
@@ -20,7 +20,7 @@ members = ["libsodium-sys", "testcrate"]
 [dependencies]
 ed25519 = { version = "1", default-features = false }
 libc = { version = "^0.2.41" , default-features = false }
-libsodium-sys = { version = "0.2.5", path = "libsodium-sys" }
+libsodium-sys = { version = "0.2.7", path = "libsodium-sys" }
 serde = { version = "^1.0.59", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/libsodium-sys/Cargo.toml
+++ b/libsodium-sys/Cargo.toml
@@ -9,7 +9,7 @@ links = "sodium"
 name = "libsodium-sys"
 repository = "https://github.com/sodiumoxide/sodiumoxide.git"
 categories = ["cryptography", "api-bindings"]
-version = "0.2.6"
+version = "0.2.7"
 
 [build-dependencies]
 pkg-config = "0.3"


### PR DESCRIPTION
Bump sodiumoxide (and libsodium-sys) version to 0.2.7, as discussed in https://github.com/sodiumoxide/sodiumoxide/issues/457#issuecomment-864895622 , to release a new version to crates.io 

Fixes #457 
