### PR TITLE
Maintenance fixes for dependency updates

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         rust:
-          - 1.36.0
+          - 1.56.0
           - stable
           - beta
           - nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.2.8 (Jun 13, 2022)
+
+* Fix a warning about an unnamed trait parameter
+* Fix the minimum version of the `cc` dependency in libsodium-sys
+* Bump the Minimum Supported Rust Version (MSRV) to 1.56. Older releases will probably still work,
+  but they are not tested for anymore.
+
 # 0.2.7 (Jun 21, 2021)
 
 * Add ed25519 to x25519 conversion methods (#456)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "sodiumoxide"
 readme = "README.md"
 repository = "https://github.com/sodiumoxide/sodiumoxide"
 categories = ["cryptography"]
-version = "0.2.7"
+version = "0.2.8"
 exclude = [
     "**/.gitignore",
     ".github/*"
@@ -20,7 +20,7 @@ members = ["libsodium-sys", "testcrate"]
 [dependencies]
 ed25519 = { version = "1.3.0", default-features = false }
 libc = { version = "^0.2.41" , default-features = false }
-libsodium-sys = { version = "0.2.7", path = "libsodium-sys" }
+libsodium-sys = { version = "0.2.8", path = "libsodium-sys" }
 serde = { version = "^1.0.59", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 members = ["libsodium-sys", "testcrate"]
 
 [dependencies]
-ed25519 = { version = "1", default-features = false }
+ed25519 = { version = "1.3.0", default-features = false }
 libc = { version = "^0.2.41" , default-features = false }
 libsodium-sys = { version = "0.2.7", path = "libsodium-sys" }
 serde = { version = "^1.0.59", default-features = false, optional = true }

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ deprecate it.
 
 This package aims to provide a type-safe and efficient Rust binding that's just
 as easy to use.
-Rust >= 1.36.0 is required because of mem::MaybeUninit.
+Rust >= 1.56.0 is required because the latest versions of some dependencies use `edition = "2021"` - by downgrading dependencies, the crate should be compatible with Rust >= 1.36.0.
 
 ## Basic usage
 
@@ -176,7 +176,7 @@ linker = "arm-buildroot-linux-musleabihf-gcc"
 2. Dockerfile:
 
 ```
-FROM rust:1.36.0
+FROM rust:1.56.0
 
 ENV TARGET="armv7-unknown-linux-musleabihf"
 

--- a/libsodium-sys/Cargo.toml
+++ b/libsodium-sys/Cargo.toml
@@ -9,7 +9,7 @@ links = "sodium"
 name = "libsodium-sys"
 repository = "https://github.com/sodiumoxide/sodiumoxide.git"
 categories = ["cryptography", "api-bindings"]
-version = "0.2.7"
+version = "0.2.8"
 
 [build-dependencies]
 pkg-config = "0.3"

--- a/libsodium-sys/Cargo.toml
+++ b/libsodium-sys/Cargo.toml
@@ -19,7 +19,7 @@ walkdir = "2"
 libc = { version = "0.2" , default-features = false }
 
 [target.'cfg(not(target_env = "msvc"))'.build-dependencies]
-cc = "1.0"
+cc = "1.0.3"
 
 [dependencies]
 libc = { version = "0.2" , default-features = false }

--- a/libsodium-sys/build.rs
+++ b/libsodium-sys/build.rs
@@ -9,6 +9,7 @@ extern crate walkdir;
 
 use std::{
     env,
+    fmt::Write,
     path::{Path, PathBuf},
 };
 
@@ -182,35 +183,45 @@ fn make_libsodium(target: &str, source_dir: &Path, install_dir: &Path) -> PathBu
         match &*target {
             "aarch64-apple-ios" => {
                 cflags += " -arch arm64";
-                cflags += &format!(" -isysroot {}", sdk_dir_ios);
-                cflags += &format!(" -mios-version-min={}", ios_version_min);
+                write!(cflags, " -isysroot {}", sdk_dir_ios).unwrap();
+                write!(cflags, " -mios-version-min={}", ios_version_min).unwrap();
                 cflags += " -fembed-bitcode";
                 host_arg = "--host=arm-apple-darwin10".to_string();
             }
             "armv7-apple-ios" => {
                 cflags += " -arch armv7";
-                cflags += &format!(" -isysroot {}", sdk_dir_ios);
-                cflags += &format!(" -mios-version-min={}", ios_version_min);
+                write!(cflags, " -isysroot {}", sdk_dir_ios).unwrap();
+                write!(cflags, " -mios-version-min={}", ios_version_min).unwrap();
                 cflags += " -mthumb";
                 host_arg = "--host=arm-apple-darwin10".to_string();
             }
             "armv7s-apple-ios" => {
                 cflags += " -arch armv7s";
-                cflags += &format!(" -isysroot {}", sdk_dir_ios);
-                cflags += &format!(" -mios-version-min={}", ios_version_min);
+                write!(cflags, " -isysroot {}", sdk_dir_ios).unwrap();
+                write!(cflags, " -mios-version-min={}", ios_version_min).unwrap();
                 cflags += " -mthumb";
                 host_arg = "--host=arm-apple-darwin10".to_string();
             }
             "i386-apple-ios" => {
                 cflags += " -arch i386";
-                cflags += &format!(" -isysroot {}", sdk_dir_simulator);
-                cflags += &format!(" -mios-simulator-version-min={}", ios_simulator_version_min);
+                write!(cflags, " -isysroot {}", sdk_dir_simulator).unwrap();
+                write!(
+                    cflags,
+                    " -mios-simulator-version-min={}",
+                    ios_simulator_version_min
+                )
+                .unwrap();
                 host_arg = "--host=i686-apple-darwin10".to_string();
             }
             "x86_64-apple-ios" => {
                 cflags += " -arch x86_64";
-                cflags += &format!(" -isysroot {}", sdk_dir_simulator);
-                cflags += &format!(" -mios-simulator-version-min={}", ios_simulator_version_min);
+                write!(cflags, " -isysroot {}", sdk_dir_simulator).unwrap();
+                write!(
+                    cflags,
+                    " -mios-simulator-version-min={}",
+                    ios_simulator_version_min
+                )
+                .unwrap();
                 host_arg = "--host=x86_64-apple-darwin10".to_string();
             }
             _ => panic!("Unknown iOS build target: {}", target),

--- a/src/crypto/secretbox/xsalsa20poly1305.rs
+++ b/src/crypto/secretbox/xsalsa20poly1305.rs
@@ -68,13 +68,15 @@ pub fn seal(m: &[u8], n: &Nonce, k: &Key) -> Vec<u8> {
     let clen = m.len() + MACBYTES;
     let mut c = Vec::with_capacity(clen);
     unsafe {
-        ffi::crypto_secretbox_easy(
+        let ret = ffi::crypto_secretbox_easy(
             c.as_mut_ptr(),
             m.as_ptr(),
             m.len() as u64,
             n.0.as_ptr(),
             k.0.as_ptr(),
         );
+
+        assert!(ret == 0);
         c.set_len(clen);
     }
     c

--- a/src/crypto/sign/ed25519.rs
+++ b/src/crypto/sign/ed25519.rs
@@ -164,7 +164,7 @@ pub fn sign_detached(m: &[u8], sk: &SecretKey) -> Signature {
         );
     }
     assert_eq!(siglen, SIGNATUREBYTES as c_ulonglong);
-    Signature::new(sig)
+    Signature::from_bytes(&sig).expect("ed25519 signature produced by libsodium was invalid")
 }
 
 /// `verify_detached()` verifies the signature in `sig` against the message `m`
@@ -220,7 +220,7 @@ impl State {
             );
         }
         assert_eq!(siglen, SIGNATUREBYTES as c_ulonglong);
-        Signature::new(sig)
+        Signature::from_bytes(&sig).expect("ed25519 signature produced by libsodium was invalid")
     }
 
     /// `verify` verifies the signature in `sm` using the signer's public key `pk`.
@@ -336,7 +336,9 @@ mod test {
             let mut sig = sign_detached(&m, &sk).to_bytes();
             for j in 0..SIGNATUREBYTES {
                 sig[j] ^= 0x20;
-                assert!(!verify_detached(&Signature::new(sig), &m, &pk));
+                if let Ok(sig) = Signature::from_bytes(&sig) {
+                    assert!(!verify_detached(&sig, &m, &pk));
+                }
                 sig[j] ^= 0x20;
             }
         }

--- a/src/newtype_macros.rs
+++ b/src/newtype_macros.rs
@@ -172,7 +172,7 @@ macro_rules! public_newtype_traits (($newtype:ident) => (
 /// Usage:
 /// Generating secret datatypes, e.g. keys
 ///
-/// ```
+/// ```ignore
 /// new_type! {
 ///     /// This is some documentation for our type
 ///     secret Key(KEYBYTES);
@@ -181,17 +181,16 @@ macro_rules! public_newtype_traits (($newtype:ident) => (
 ///
 /// Generating public datatypes, e.g. public keys
 ///
-/// ```
+/// ```ignore
 /// new_type! {
 ///     /// This is some documentation for our type
 ///     public PublicKey(PUBLICKEYBYTES);
 /// }
-///
 /// ```
 ///
 /// Generating nonce types
 ///
-/// ```
+/// ```ignore
 /// new_type! {
 ///     /// This is some documentation for our type
 ///     nonce Nonce(NONCEBYTES);


### PR DESCRIPTION
Hi! I know the README says you'll only accept security fixes, but I'm trying my luck with sneaking these maintenance fixes in anyway.

`ed25519` version 1.3.0 changed `Signature::new()` to panic on invalid data, which broke tests and caused deprecation warnings; I fixed that and bumped the dep version.

`build.rs` uses `cc::Tool::cflags_env()`, which was introduced in cc 1.0.3. Specifying a too-low dependency breaks any `-Z minimum-versions` builds downstream, I bumped the dep version there as well.

I also prepared a release commit that bumps the version numbers and updates the changelog, I can of course remove that though if you want to do it yourself.